### PR TITLE
fix: Interactableコンポーネントが<RigidBody>内の<mesh>にアウトラインを表示できない問題を修正

### DIFF
--- a/src/components/Interactable/index.tsx
+++ b/src/components/Interactable/index.tsx
@@ -58,30 +58,54 @@ export const Interactable: FC<Props> = ({
   // 現在のターゲットかどうかで視覚的フィードバックを提供
   const isTargeted = currentTarget !== null && currentTarget.uuid === groupRef.current?.uuid
 
-  // 子要素（mesh）に<Outlines>を追加
-  const childrenWithOutlines = Children.map(children, (child) => {
+  // 再帰的に子要素を探索して、すべての<mesh>に<Outlines>を追加する関数
+  const addOutlinesToMeshes = (child: React.ReactNode): React.ReactNode => {
     if (!isValidElement(child)) return child
 
-    // meshの子要素として<Outlines>を追加
-    return cloneElement(child, {
-      children: (
-        <>
-          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-          {(child.props as any).children}
-          {isTargeted && enabled && (
-            <Outlines
-              thickness={5}
-              color="#4dabf7"
-              screenspace={false}
-              opacity={1}
-              transparent={false}
-              angle={Math.PI}
-            />
-          )}
-        </>
-      ),
-    } as never)
-  })
+    // 子要素のtypeをチェック（meshかどうか）
+    const childType = child.type
+    const isMesh = typeof childType === 'string' && childType === 'mesh'
+
+    // meshの場合、Outlinesを子要素として追加
+    if (isMesh) {
+      return cloneElement(child, {
+        children: (
+          <>
+            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+            {(child.props as any).children}
+            {isTargeted && enabled && (
+              <Outlines
+                thickness={5}
+                color="#4dabf7"
+                screenspace={false}
+                opacity={1}
+                transparent={false}
+                angle={Math.PI}
+              />
+            )}
+          </>
+        ),
+      } as never)
+    }
+
+    // mesh以外の場合、子要素を再帰的に処理
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const grandChildren = (child.props as any).children
+    if (grandChildren) {
+      return cloneElement(child, {
+        children: Children.map(grandChildren, (grandChild) =>
+          addOutlinesToMeshes(grandChild)
+        ),
+      } as never)
+    }
+
+    return child
+  }
+
+  // 子要素（mesh）に<Outlines>を追加
+  const childrenWithOutlines = Children.map(children, (child) =>
+    addOutlinesToMeshes(child)
+  )
 
   return (
     <group ref={groupRef}>


### PR DESCRIPTION
## 概要
`Interactable`コンポーネントを`<RigidBody>`の子要素として使用した場合、アウトラインが表示されない問題を修正しました。

## 変更内容
- 子要素を再帰的に探索してすべての`<mesh>`に`<Outlines>`を追加するように変更
- `addOutlinesToMeshes`関数を追加し、ネストされた構造の中の`<mesh>`要素を見つけ出す
- これにより`<RigidBody>`の中の`<mesh>`にも正しくアウトラインが表示されるようになる

## 修正前の動作
```tsx
<Interactable id="sample-button" onInteract={handleInteract}>
  <RigidBody type="fixed">
    <mesh>
      <boxGeometry args={[1, 0.3, 1]} />
      <meshStandardMaterial color="#4a9eff" />
    </mesh>
  </RigidBody>
</Interactable>
```

上記のようなコードで、カーソルを合わせてもアウトラインが表示されませんでした。

## 修正後の動作
同じコードで、カーソルを合わせるとアウトラインが正しく表示されます。

## テストプラン
- [ ] `xrift-world-template`で`<RigidBody>`内の`<mesh>`を持つ`Interactable`コンポーネントを作成
- [ ] ワールドをビルドしてフロントエンドにアップロード
- [ ] インスタンス画面でオブジェクトにカーソルを合わせてアウトラインが表示されることを確認

## 関連Issue
Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)