### PR TITLE
feat: Interactableコンポーネントにオブジェクト登録機能を追加

### DIFF
--- a/src/components/Interactable/index.tsx
+++ b/src/components/Interactable/index.tsx
@@ -14,10 +14,10 @@ export const Interactable: FC<Props> = ({
   enabled = true,
   children,
 }) => {
-  const { currentTarget } = useXRift()
+  const { currentTarget, registerInteractable, unregisterInteractable } = useXRift()
   const groupRef = useRef<Group>(null)
 
-  // userDataにインタラクション情報を設定 & レイヤー設定
+  // userDataにインタラクション情報を設定 & レイヤー設定 & オブジェクト登録
   useEffect(() => {
     const object = groupRef.current
     if (!object) return
@@ -38,8 +38,14 @@ export const Interactable: FC<Props> = ({
       child.layers.enable(INTERACTABLE_LAYER)
     })
 
+    // インタラクト可能オブジェクトとして登録
+    registerInteractable(object)
+
     // クリーンアップ: userDataからインタラクション情報を削除
     return () => {
+      // 登録解除
+      unregisterInteractable(object)
+
       if (object.userData) {
         delete object.userData.id
         delete object.userData.type
@@ -53,7 +59,7 @@ export const Interactable: FC<Props> = ({
         child.layers.disable(INTERACTABLE_LAYER)
       })
     }
-  }, [id, type, onInteract, interactionText, enabled])
+  }, [id, type, onInteract, interactionText, enabled, registerInteractable, unregisterInteractable])
 
   // 現在のターゲットかどうかで視覚的フィードバックを提供
   const isTargeted = currentTarget !== null && currentTarget.uuid === groupRef.current?.uuid

--- a/src/contexts/XRiftContext.tsx
+++ b/src/contexts/XRiftContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useContext } from 'react'
+import { createContext, type ReactNode, useCallback, useContext, useState } from 'react'
 import type { Object3D } from 'three'
 
 export interface XRiftContextValue {
@@ -12,6 +12,19 @@ export interface XRiftContextValue {
    * xrift-frontend側のRaycastDetectorが設定する
    */
   currentTarget: Object3D | null
+  /**
+   * インタラクト可能なオブジェクトのセット
+   * レイキャストのパフォーマンス最適化のために使用
+   */
+  interactableObjects: Set<Object3D>
+  /**
+   * インタラクト可能なオブジェクトを登録
+   */
+  registerInteractable: (object: Object3D) => void
+  /**
+   * インタラクト可能なオブジェクトの登録を解除
+   */
+  unregisterInteractable: (object: Object3D) => void
   // 将来的に追加可能な値
   // worldId?: string
   // instanceId?: string
@@ -36,11 +49,27 @@ interface Props {
  * 必要な情報を注入するために使用
  */
 export const XRiftProvider = ({ baseUrl, currentTarget = null, children }: Props) => {
+  // インタラクト可能なオブジェクトの管理
+  const [interactableObjects] = useState(() => new Set<Object3D>())
+
+  // オブジェクトの登録
+  const registerInteractable = useCallback((object: Object3D) => {
+    interactableObjects.add(object)
+  }, [interactableObjects])
+
+  // オブジェクトの登録解除
+  const unregisterInteractable = useCallback((object: Object3D) => {
+    interactableObjects.delete(object)
+  }, [interactableObjects])
+
   return (
     <XRiftContext.Provider
       value={{
         baseUrl,
         currentTarget,
+        interactableObjects,
+        registerInteractable,
+        unregisterInteractable,
       }}
     >
       {children}


### PR DESCRIPTION
## 概要
Interactableコンポーネントにインタラクト可能オブジェクトの自動登録機能を追加し、レイキャストのパフォーマンスを最適化するための基盤を提供します。

## 変更内容

### XRiftContext の拡張
- `interactableObjects: Set<Object3D>` を追加
- `registerInteractable(object: Object3D)` メソッドを追加
- `unregisterInteractable(object: Object3D)` メソッドを追加

### Interactable コンポーネントの修正
- マウント時に自動的に `registerInteractable` でオブジェクトを登録
- アンマウント時に自動的に `unregisterInteractable` で登録解除
- useEffectの依存配列に `registerInteractable` と `unregisterInteractable` を追加

## 期待される効果
- レイキャストのトラバース対象が大幅に削減される（推定50-80%削減）
- scene全体（数百〜数千オブジェクト）→ 登録済みInteractableのみ（数個〜数十個）
- カメラ回転時の滑らかさが向上

## xrift-frontend 側での利用方法
frontend側のRaycastDetectorで `interactableObjects` を参照することで、登録済みのオブジェクトのみをトラバースできます：

```typescript
const { interactableObjects } = useXRift()

// scene.children全体をトラバースする代わりに
// interactableObjectsのみをチェック
for (const object of interactableObjects) {
  // レイキャスト処理
}
```

## テストプラン
- [ ] `xrift-world-template`で複数のInteractableコンポーネントを作成
- [ ] frontend側でinteractableObjectsを確認し、正しく登録されているか確認
- [ ] コンポーネントのアンマウント時に正しく登録解除されるか確認
- [ ] RaycastDetectorで登録済みオブジェクトのみをトラバースするように変更してパフォーマンスを測定

## 関連Issue
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)