### PR TITLE
fix: React Hooks ルール違反を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/contexts/InstanceStateContext.tsx
+++ b/src/contexts/InstanceStateContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useContext, useState } from 'react'
+import { createContext, type ReactNode, useContext } from 'react'
 
 /**
  * インスタンス状態を管理するためのインターフェース
@@ -6,38 +6,29 @@ import { createContext, type ReactNode, useContext, useState } from 'react'
  */
 export interface InstanceStateContextValue {
   /**
-   * 指定されたIDの状態を取得する
-   * @param stateId 状態の一意識別子
-   * @param initialState 初期状態
-   * @returns [現在の状態, 状態更新関数]
+   * 全ての状態を保持するMap
+   * stateId -> 状態の値
    */
-  getState: <T>(
-    stateId: string,
-    initialState: T
-  ) => [T, (state: T | ((prevState: T) => T)) => void]
+  states: Map<string, unknown>
+  /**
+   * 状態を送信する関数
+   * @param stateId 状態の一意識別子
+   * @param payload 送信する状態
+   */
+  sendState: (stateId: string, payload: unknown) => void
 }
 
 /**
- * デフォルト実装: Context未設定時はローカルuseStateとして動作
+ * デフォルト実装: Context未設定時はローカル状態として動作
  * 開発時やテスト時に使用される
  */
 const createDefaultImplementation = (): InstanceStateContextValue => {
-  const stateMap = new Map<string, any>()
-  const setterMap = new Map<string, (value: any) => void>()
+  const states = new Map<string, unknown>()
 
   return {
-    getState: <T,>(stateId: string, initialState: T) => {
-      // このstateIdで既に状態が存在する場合は既存の状態を返す
-      if (stateMap.has(stateId)) {
-        return [stateMap.get(stateId), setterMap.get(stateId)!]
-      }
-
-      // 新しい状態を作成
-      const [state, setState] = useState<T>(initialState)
-      stateMap.set(stateId, state)
-      setterMap.set(stateId, setState)
-
-      return [state, setState]
+    states,
+    sendState: (stateId: string, payload: unknown) => {
+      states.set(stateId, payload)
     },
   }
 }


### PR DESCRIPTION
## 概要

Issue #11 に基づき、useInstanceStateの実装がReact Hooksのルール「条件付きで呼び出してはいけない」に違反していた問題を修正しました。

## 問題点

PR #10 でマージされた実装では、`InstanceStateContext.tsx` の `createDefaultImplementation()` 内で条件付きに `useState` を呼び出していました:

```typescript
getState: <T,>(stateId: string, initialState: T) => {
  if (stateMap.has(stateId)) {
    return [stateMap.get(stateId), setterMap.get(stateId)!]
  }
  
  // 新しい状態を作成
  const [state, setState] = useState<T>(initialState)  // ← 問題！
  stateMap.set(stateId, state)
  setterMap.set(stateId, setState)
  
  return [state, setState]
}
```

これは **React Hooks のルール「条件分岐、ループ、ネストされた関数の中で呼び出してはいけない」に違反** しており、xrift-frontendで実装したところ、状態が正しく同期されない問題が発生しました。

## 解決策

xrift-frontend で動作実績のある実装に変更しました:

### 1. `InstanceStateContextValue` インターフェースを変更

```typescript
// 変更前
export interface InstanceStateContextValue {
  getState: <T>(stateId: string, initialState: T) => [T, (state: T | ((prevState: T) => T)) => void]
}

// 変更後
export interface InstanceStateContextValue {
  states: Map<string, unknown>
  sendState: (stateId: string, payload: unknown) => void
}
```

### 2. `useInstanceState` の実装を変更

```typescript
export function useInstanceState<T>(
  stateId: string,
  initialState: T
): [T, (state: T | ((prevState: T) => T)) => void] {
  const { states, sendState } = useInstanceStateContext()
  
  // ローカル状態を保持して即座に更新を反映
  const [localState, setLocalState] = useState<T>(() => {
    return (states.get(stateId) as T | undefined) ?? initialState
  })

  // グローバル状態が変更されたらローカル状態を更新
  useEffect(() => {
    const globalState = states.get(stateId) as T | undefined
    if (globalState !== undefined) {
      setLocalState(globalState)
    }
  }, [states, stateId])

  // 関数型setStateをサポート
  const setState = (newStateOrUpdater: T | ((prevState: T) => T)) => {
    setLocalState(prev => {
      const newState = typeof newStateOrUpdater === 'function'
        ? (newStateOrUpdater as (prevState: T) => T)(prev)
        : newStateOrUpdater

      sendState(stateId, newState)
      return newState
    })
  }

  return [localState, setState]
}
```

## メリット

- ✅ React Hooks のルールに完全に準拠
- ✅ 毎回同じ順序で `useState` と `useEffect` が呼ばれる
- ✅ シンプルで理解しやすい実装
- ✅ xrift-frontend で動作実績あり

## 破壊的変更

`InstanceStateContextValue` のインターフェースが変更されたため、バージョンを `0.5.0` に更新しました。

## プラットフォーム側（xrift-frontend）の対応

```typescript
// 変更前
const implementation = {
  getState: (stateId, initialState) => { ... }
}

// 変更後
const implementation = {
  states: instanceStatesMap,
  sendState: (stateId, payload) => { ... }
}
```

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)