### PR TITLE
feat: Skyboxコンポーネントを追加、Triplex設定を追加

### DIFF
--- a/.triplex/README.md
+++ b/.triplex/README.md
@@ -1,0 +1,1 @@
+[Learn how to configure Triplex](https://triplex.dev/docs/api-reference/config-options).

--- a/.triplex/config.json
+++ b/.triplex/config.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://triplex.dev/config.schema.json",
+  "components": ["../src/components/*/index.tsx"],
+  "files": ["../src/**/*.tsx"],
+  "provider": "./provider.tsx",
+  "experimental": {
+    "xr_editing": true
+  }
+}

--- a/.triplex/provider.tsx
+++ b/.triplex/provider.tsx
@@ -1,0 +1,14 @@
+import { Skybox } from '../src/components/Skybox'
+
+export function CanvasProvider({
+  children,
+}: {
+  children?: React.ReactNode
+}) {
+  return (
+    <>
+      <Skybox />
+      {children}
+    </>
+  )
+}

--- a/README.md
+++ b/README.md
@@ -184,6 +184,43 @@ function MyWorld() {
 - 物理コライダーは含まれていません。必要な場合は`@react-three/rapier`などを使って別途追加してください
 - Meta Quest（Android Chrome）での互換性のため、マルチサンプリングは無効化されています
 
+### Skybox コンポーネント
+
+画像を使わずにグラデーションで空を表現するシンプルなskyboxコンポーネントです。
+
+```tsx
+import { Skybox } from '@xrift/world-components'
+
+function MyWorld() {
+  return (
+    <>
+      {/* 基本的な使い方（デフォルトは空色→白） */}
+      <Skybox />
+
+      {/* 夕焼け風 */}
+      <Skybox topColor={0xff6b35} bottomColor={0xffd93d} />
+
+      {/* 夜空風 */}
+      <Skybox topColor={0x000033} bottomColor={0x000011} />
+    </>
+  )
+}
+```
+
+#### Props
+
+| プロパティ | 型 | 必須 | デフォルト | 説明 |
+|-----------|-----|------|-----------|------|
+| `topColor` | `number` | - | `0x87ceeb` | 上部の色（16進数カラー） |
+| `bottomColor` | `number` | - | `0xffffff` | 下部の色（16進数カラー） |
+| `offset` | `number` | - | `0` | グラデーションの開始位置 |
+| `exponent` | `number` | - | `1` | グラデーションの範囲 |
+
+#### 注意事項
+
+- シェーダーを使用した軽量な実装です
+- シーンの背景色も自動的に設定されます
+
 ## 開発
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,27 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.1.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "^9.4.0",
         "@types/react": "^18.3.12",
         "@types/three": "^0.181.0",
+        "react-dom": "^19.2.0",
         "three": "^0.181.0",
         "typescript": "^5.6.3"
       },
       "peerDependencies": {
-        "@react-three/drei": "^9.0.0",
-        "@react-three/fiber": "^8.0.0",
+        "@react-three/drei": "^10.0.0",
+        "@react-three/fiber": "^9.0.0",
         "react": "^18.0.0 || ^19.0.0",
-        "three": "^0.150.0"
+        "three": ">=0.176.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -547,6 +548,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-reconciler": {
       "version": "0.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -39,6 +39,7 @@
     "@react-three/fiber": "^9.4.0",
     "@types/react": "^18.3.12",
     "@types/three": "^0.181.0",
+    "react-dom": "^19.2.0",
     "three": "^0.181.0",
     "typescript": "^5.6.3"
   }

--- a/src/components/Skybox/index.tsx
+++ b/src/components/Skybox/index.tsx
@@ -1,0 +1,65 @@
+import { useThree } from '@react-three/fiber'
+import { useEffect, useMemo } from 'react'
+import { BackSide, Color, ShaderMaterial, SphereGeometry } from 'three'
+import { SkyboxProps } from './types'
+
+export type { SkyboxProps } from './types'
+
+const vertexShader = `
+  varying vec3 vWorldPosition;
+  void main() {
+    vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+    vWorldPosition = worldPosition.xyz;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`
+
+const fragmentShader = `
+  uniform vec3 topColor;
+  uniform vec3 bottomColor;
+  uniform float offset;
+  uniform float exponent;
+  varying vec3 vWorldPosition;
+  void main() {
+    float h = normalize(vWorldPosition + offset).y;
+    gl_FragColor = vec4(mix(bottomColor, topColor, max(pow(max(h, 0.0), exponent), 0.0)), 1.0);
+  }
+`
+
+export function Skybox({
+  topColor = 0x87ceeb,
+  bottomColor = 0xffffff,
+  offset = 0,
+  exponent = 1,
+}: SkyboxProps) {
+  const { scene } = useThree()
+
+  const material = useMemo(() => {
+    return new ShaderMaterial({
+      vertexShader,
+      fragmentShader,
+      uniforms: {
+        topColor: { value: new Color(topColor) },
+        bottomColor: { value: new Color(bottomColor) },
+        offset: { value: offset },
+        exponent: { value: exponent },
+      },
+      side: BackSide,
+      depthWrite: false,
+    })
+  }, [topColor, bottomColor, offset, exponent])
+
+  const geometry = useMemo(() => new SphereGeometry(500, 32, 15), [])
+
+  useEffect(() => {
+    // 背景色を設定
+    const originalBackground = scene.background
+    scene.background = new Color(bottomColor)
+
+    return () => {
+      scene.background = originalBackground
+    }
+  }, [scene, bottomColor])
+
+  return <mesh geometry={geometry} material={material} />
+}

--- a/src/components/Skybox/types.ts
+++ b/src/components/Skybox/types.ts
@@ -1,0 +1,10 @@
+export interface SkyboxProps {
+  /** 上部の色（デフォルト: 0x87ceeb - 空色） */
+  topColor?: number
+  /** 下部の色（デフォルト: 0xffffff - 白） */
+  bottomColor?: number
+  /** グラデーションの開始位置（デフォルト: 0） */
+  offset?: number
+  /** グラデーションの範囲（デフォルト: 1） */
+  exponent?: number
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,5 +20,7 @@ export {
 
 export { Mirror, type MirrorProps } from './components/Mirror'
 
+export { Skybox, type SkyboxProps } from './components/Skybox'
+
 // Hooks
 export { useInstanceState } from './hooks/useInstanceState'


### PR DESCRIPTION
## 概要

画像を使わないグラデーションskyboxコンポーネントと、Triplex開発環境の設定を追加しました。

## 主な変更

### Skyboxコンポーネント

- **グラデーションベースのskybox**
  - 画像ファイル不要、シェーダーで生成
  - 軽量で高速
  - `topColor`、`bottomColor`で色をカスタマイズ可能
  - デフォルトは空色→白のグラデーション

### Triplex設定

- **.triplex/** ディレクトリを追加
  - `config.json`: コンポーネントとファイルの設定
  - `provider.tsx`: Skyboxを含むCanvasProvider
  - XR編集モードを有効化

### その他

- READMEにSkyboxのドキュメントと使用例を追加
- バージョンを0.7.0に更新

## 使用例

```tsx
import { Skybox } from '@xrift/world-components'

// デフォルト（空色）
<Skybox />

// 夕焼け
<Skybox topColor={0xff6b35} bottomColor={0xffd93d} />

// 夜空
<Skybox topColor={0x000033} bottomColor={0x000011} />
```

## Triplex

コンポーネントをTriplexエディタで開くと、自動的にSkyboxが配置された状態で編集できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)