### PR TITLE
fix: Interactable コンポーネントのパフォーマンス改善

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ export {
   XRiftContext,
   XRiftProvider,
   useXRift,
+  CurrentTargetContext,
+  useCurrentTarget,
   type XRiftContextValue,
 } from './contexts/XRiftContext'
 


### PR DESCRIPTION
## Summary
- XRiftProvider の value を useMemo でメモ化して、不要な再レンダリングを防止
- currentTarget を別の Context (CurrentTargetContext) に分離し、ターゲット変更時に全 Interactable が再レンダリングされる問題を解決
- Interactable で isTargeted が false の場合、重い cloneElement 処理をスキップ

## 変更内容

### XRiftContext.tsx
- `XRiftContextValue` から `currentTarget` を分離
- 新しい `CurrentTargetContext` を作成
- `XRiftProvider` の value を `useMemo` でメモ化
- 新しい `useCurrentTarget` hook を追加

### Interactable/index.tsx
- `useXRift` から `currentTarget` を取得する代わりに `useCurrentTarget` を使用
- `isTargeted` が false の場合、元の children をそのまま返すように最適化

### index.ts
- `CurrentTargetContext` と `useCurrentTarget` をエクスポートに追加

## 影響
この変更は破壊的変更を含みます：
- `XRiftContextValue.currentTarget` が削除されました
- `currentTarget` を使用していたコードは `useCurrentTarget()` を使用するように更新が必要です

Fixes #26

## Test plan
- [ ] 複数のユーザーがいるインスタンスでレイキャスト時にFPSが低下しないことを確認
- [ ] Interactable オブジェクトにレイを当てた時にアウトラインが正しく表示されることを確認
- [ ] レイを外した時にアウトラインが消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)