### PR TITLE
Revert: ヘルパー矢印の向きを元に戻す

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/SpawnPoint/index.tsx
+++ b/src/components/SpawnPoint/index.tsx
@@ -113,7 +113,7 @@ export const SpawnPoint: FC<SpawnPointProps> = ({
           </mesh>
 
           {/* 矢印（向きを示す） */}
-          <group>
+          <group rotation={[0, Math.PI, 0]}>
             {/* 矢印の軸 */}
             <mesh position={[0, 0.3, -0.05]} rotation={[Math.PI / 2, 0, 0]}>
               <cylinderGeometry args={[0.03, 0.03, 0.4, 15]} />


### PR DESCRIPTION
## Summary
- PR #38 の変更を元に戻す
- バージョン0.12.5に更新

## Test plan
- [ ] SpawnPointのヘルパー矢印がyawの方向を正しく示していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)