### PR TITLE
feat: ワールド作者向けに useUsers() hooks を提供する

### DIFF
--- a/src/contexts/UsersContext.tsx
+++ b/src/contexts/UsersContext.tsx
@@ -1,0 +1,86 @@
+import { createContext, type ReactNode, useContext } from 'react'
+
+/**
+ * ユーザー情報の型定義
+ */
+export interface User {
+  /** ユーザーID */
+  id: string
+  /** 表示名 */
+  displayName: string
+  /** アバターアイコンURL */
+  avatarUrl: string | null
+  /** ゲストかどうか */
+  isGuest: boolean
+}
+
+/**
+ * ユーザー情報を管理するためのインターフェース
+ * プラットフォーム側（xrift-frontend）が実装を注入する
+ */
+export interface UsersContextValue {
+  /** ローカルユーザー（自分） */
+  localUser: User | null
+  /** リモートユーザー（他の参加者） */
+  remoteUsers: User[]
+}
+
+/**
+ * デフォルト実装: Context未設定時は空の状態として動作
+ * 開発時やテスト時に使用される
+ */
+const createDefaultImplementation = (): UsersContextValue => ({
+  localUser: null,
+  remoteUsers: [],
+})
+
+/**
+ * ユーザー情報を管理するContext
+ * ワールド作成者はこのContextを通じてユーザー情報にアクセスする
+ */
+export const UsersContext = createContext<UsersContextValue>(
+  createDefaultImplementation()
+)
+
+interface Props {
+  /**
+   * プラットフォーム側が提供する実装
+   * 未指定の場合はデフォルト実装（空の状態）が使用される
+   */
+  implementation?: UsersContextValue
+  children: ReactNode
+}
+
+/**
+ * ユーザー情報を提供するContextProvider
+ * プラットフォーム側（xrift-frontend）が実装を注入するために使用
+ *
+ * @example
+ * // プラットフォーム側での使用例
+ * <UsersProvider implementation={usersImplementation}>
+ *   <WorldComponent />
+ * </UsersProvider>
+ */
+export const UsersProvider = ({ implementation, children }: Props) => {
+  const value = implementation ?? createDefaultImplementation()
+
+  return (
+    <UsersContext.Provider value={value}>
+      {children}
+    </UsersContext.Provider>
+  )
+}
+
+/**
+ * ユーザー情報を取得するhook
+ * ワールド作成者が現在のユーザー情報（自分＋他の参加者）を取得するために使用
+ *
+ * @example
+ * const { localUser, remoteUsers } = useUsers()
+ *
+ * // localUser: { id, displayName, avatarUrl, isGuest }
+ * // remoteUsers: [{ id, displayName, avatarUrl, isGuest }, ...]
+ */
+export const useUsers = (): UsersContextValue => {
+  return useContext(UsersContext)
+}

--- a/src/contexts/XRiftContext.tsx
+++ b/src/contexts/XRiftContext.tsx
@@ -3,6 +3,7 @@ import type { Object3D } from 'three'
 import { InstanceStateProvider, type InstanceStateContextValue } from './InstanceStateContext'
 import { ScreenShareProvider, type ScreenShareContextValue } from './ScreenShareContext'
 import { SpawnPointProvider, type SpawnPointContextValue } from './SpawnPointContext'
+import { UsersProvider, type UsersContextValue } from './UsersContext'
 
 // デフォルトの画面共有実装（開発環境用）
 const createDefaultScreenShareImplementation = (): ScreenShareContextValue => ({
@@ -60,6 +61,11 @@ interface Props {
    * 指定しない場合はデフォルト実装（ローカルstate）が使用される
    */
   spawnPointImplementation?: SpawnPointContextValue
+  /**
+   * ユーザー情報の実装（オプション）
+   * 指定しない場合はデフォルト実装（空の状態）が使用される
+   */
+  usersImplementation?: UsersContextValue
   children: ReactNode
 }
 
@@ -73,6 +79,7 @@ export const XRiftProvider = ({
   instanceStateImplementation,
   screenShareImplementation,
   spawnPointImplementation,
+  usersImplementation,
   children,
 }: Props) => {
   // インタラクト可能なオブジェクトの管理
@@ -106,7 +113,9 @@ export const XRiftProvider = ({
       <ScreenShareProvider value={screenShareImpl}>
         <InstanceStateProvider implementation={instanceStateImplementation}>
           <SpawnPointProvider implementation={spawnPointImplementation}>
-            {children}
+            <UsersProvider implementation={usersImplementation}>
+              {children}
+            </UsersProvider>
           </SpawnPointProvider>
         </InstanceStateProvider>
       </ScreenShareProvider>

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,14 @@ export {
   type SpawnPointContextValue,
 } from './contexts/SpawnPointContext'
 
+export {
+  UsersContext,
+  UsersProvider,
+  useUsers,
+  type User,
+  type UsersContextValue,
+} from './contexts/UsersContext'
+
 // Components
 export {
   Interactable,


### PR DESCRIPTION
## Summary
- `useUsers()` hooks を追加し、ワールド作者が現在のユーザー情報（自分＋他の参加者）を取得できるようにした
- `User` 型、`UsersContextValue` 型を提供
- `XRiftProvider` に `usersImplementation` props を追加

## 使い方
```tsx
import { useUsers } from '@xrift/world-components'

function MyWorld() {
  const { localUser, remoteUsers } = useUsers()
  // localUser: { id, displayName, avatarUrl, isGuest }
  // remoteUsers: [{ id, displayName, avatarUrl, isGuest }, ...]
  return <mesh />
}
```

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)