### PR TITLE
refactor: User 型に socketId を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",

--- a/src/contexts/UsersContext.tsx
+++ b/src/contexts/UsersContext.tsx
@@ -5,8 +5,10 @@ import type { PlayerMovement } from '../types/movement'
  * ユーザー情報の型定義
  */
 export interface User {
-  /** ユーザーID */
+  /** 認証ユーザーID（一貫性がある、フレンド機能等で使用） */
   id: string
+  /** ソケットID（接続固有、プラットフォーム内部で使用） */
+  socketId: string
   /** 表示名 */
   displayName: string
   /** アバターアイコンURL */
@@ -40,7 +42,7 @@ export interface UsersContextValue {
   /**
    * 指定したユーザーの位置情報を取得
    * useFrame内で毎フレーム呼び出しても再レンダリングを引き起こさない
-   * @param userId - ユーザーID
+   * @param userId - 認証ユーザーID
    * @returns PlayerMovement または undefined（ユーザーが存在しない場合）
    */
   getMovement: (userId: string) => PlayerMovement | undefined


### PR DESCRIPTION
## Summary

- `User` 型に `socketId` プロパティを追加（接続固有のID）
- `id` プロパティのコメントを明確化（認証ユーザーID）
- `getMovement` の引数コメントを明確化

## 変更後の User 型

```typescript
export interface User {
  /** 認証ユーザーID（一貫性がある、フレンド機能等で使用） */
  id: string
  /** ソケットID（接続固有、プラットフォーム内部で使用） */
  socketId: string
  /** 表示名 */
  displayName: string
  /** アバターアイコンURL */
  avatarUrl: string | null
  /** ゲストかどうか */
  isGuest: boolean
}
```

## 関連

- xrift-frontend 側の `convertRemotePlayersToUsers` も更新が必要

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)