### PR TITLE
feat: User 型に socketId を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.13.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.13.0",
+      "version": "0.15.1",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.14.0",
+  "version": "0.15.1",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/contexts/UsersContext.tsx
+++ b/src/contexts/UsersContext.tsx
@@ -5,8 +5,10 @@ import type { PlayerMovement } from '../types/movement'
  * ユーザー情報の型定義
  */
 export interface User {
-  /** ユーザーID */
+  /** 認証ユーザーID */
   id: string
+  /** ソケット接続ID */
+  socketId: string
   /** 表示名 */
   displayName: string
   /** アバターアイコンURL */
@@ -40,10 +42,10 @@ export interface UsersContextValue {
   /**
    * 指定したユーザーの位置情報を取得
    * useFrame内で毎フレーム呼び出しても再レンダリングを引き起こさない
-   * @param userId - ユーザーID
+   * @param socketId - ソケット接続ID
    * @returns PlayerMovement または undefined（ユーザーが存在しない場合）
    */
-  getMovement: (userId: string) => PlayerMovement | undefined
+  getMovement: (socketId: string) => PlayerMovement | undefined
   /**
    * ローカルユーザー（自分）の位置情報を取得
    * useFrame内で毎フレーム呼び出しても再レンダリングを引き起こさない
@@ -118,7 +120,7 @@ export const UsersProvider = ({ implementation, children }: Props) => {
  *
  *   // 他のユーザーの位置を取得
  *   remoteUsers.forEach(user => {
- *     const movement = getMovement(user.id)
+ *     const movement = getMovement(user.socketId)
  *     if (movement) {
  *       console.log(`${user.displayName} is at`, movement.position)
  *     }


### PR DESCRIPTION
## Summary

- `User` 型に `socketId` プロパティを追加
- `getMovement` の引数を `socketId` に変更（`Map.get()` で O(1) 取得可能に）
- `id` は認証ユーザーIDとして維持

## 変更後の User 型

```typescript
export interface User {
  /** 認証ユーザーID */
  id: string
  /** ソケット接続ID */
  socketId: string
  /** 表示名 */
  displayName: string
  /** アバターアイコンURL */
  avatarUrl: string | null
  /** ゲストかどうか */
  isGuest: boolean
}
```

## 使用例

```tsx
const { remoteUsers, getMovement } = useUsers()

remoteUsers.forEach(user => {
  const movement = getMovement(user.socketId)  // socketId で取得
  console.log(user.id, movement?.position)     // id は認証ユーザーID
})
```

## 関連

- xrift-frontend 側の `convertRemotePlayersToUsers` も更新が必要

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)