### PR TITLE
fix(VideoScreen): stop video on unmount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/VideoScreen/index.tsx
+++ b/src/components/VideoScreen/index.tsx
@@ -98,6 +98,17 @@ function VideoScreenInner({
     }
   }, [currentTime, texture])
 
+  // アンマウント時に動画を停止
+  useEffect(() => {
+    const video = texture.image as HTMLVideoElement
+
+    return () => {
+      video.pause()
+      video.src = ''
+      video.load()
+    }
+  }, [texture])
+
   return (
     <group position={position} rotation={rotation}>
       <mesh>


### PR DESCRIPTION
## Summary
- アンマウント時に動画を確実に停止するクリーンアップ処理を追加
- `video.pause()`, `video.src = ''`, `video.load()` でリソースを解放
- バージョンを 0.15.3 に更新

## 修正内容
インスタンス退出後も動画の音声が再生され続ける問題を修正。`useVideoTexture` が作成する video 要素は DOM に追加されないため、コンポーネント内でクリーンアップする必要がある。

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)