### PR TITLE
fix(ScreenShareDisplay): 映像表示中は背景を非表示に

### DIFF
--- a/src/components/ScreenShareDisplay/index.tsx
+++ b/src/components/ScreenShareDisplay/index.tsx
@@ -43,18 +43,20 @@ export const ScreenShareDisplay = memo(({
         onInteract={handleInteract}
         interactionText={interactionText}
       >
-        {/* 背景（黒帯部分） */}
-        <mesh>
-          <planeGeometry args={[screenSize[0], screenSize[1]]} />
-          <meshBasicMaterial
-            side={THREE.FrontSide}
-            toneMapped={false}
-            color="#1a1a2a"
-          />
-        </mesh>
+        {/* 背景（映像がない時のみ表示） */}
+        {!hasVideo && (
+          <mesh>
+            <planeGeometry args={[screenSize[0], screenSize[1]]} />
+            <meshBasicMaterial
+              side={THREE.FrontSide}
+              toneMapped={false}
+              color="#1a1a2a"
+            />
+          </mesh>
+        )}
         {/* 映像 */}
         {hasVideo && (
-          <mesh position={[0, 0, 0.001]}>
+          <mesh>
             <planeGeometry args={[videoSize[0], videoSize[1]]} />
             <meshBasicMaterial
               ref={materialRef}


### PR DESCRIPTION
## Summary
- 画面共有中に背景（黒帯部分）がちらつく問題を修正
- 映像がある時は背景メッシュを非表示にするように変更

## Test plan
- [ ] 画面共有開始時に背景がちらつかないことを確認
- [ ] 映像がない時は背景が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)