### PR TITLE
feat(VideoScreen): 音量調整機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.15.4",
+  "version": "0.15.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.15.4",
+      "version": "0.15.6",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.15.4",
+  "version": "0.15.6",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/VideoScreen/index.tsx
+++ b/src/components/VideoScreen/index.tsx
@@ -19,6 +19,7 @@ function VideoScreenInner({
   currentTime = 0,
   sync = 'global',
   muted = false,
+  volume = 1,
 }: VideoScreenProps) {
   // グローバル同期用の状態
   const [globalState, setGlobalState] = useInstanceState<VideoState>(
@@ -82,6 +83,14 @@ function VideoScreenInner({
       video.pause()
     }
   }, [playing, texture])
+
+  // 音量の同期
+  useEffect(() => {
+    const video = texture.image as HTMLVideoElement
+    if (!video) return
+
+    video.volume = Math.max(0, Math.min(1, volume))
+  }, [volume, texture])
 
   // 再生位置の同期ロジック（VRChat方式）
   // currentTimeが外部から変更された場合のみ同期

--- a/src/components/VideoScreen/types.ts
+++ b/src/components/VideoScreen/types.ts
@@ -17,6 +17,8 @@ export interface VideoScreenProps {
   sync?: 'global' | 'local'
   /** ミュート状態（デフォルト: false）。ブラウザの自動再生ポリシーによりユーザー操作前は音声付き自動再生がブロックされる場合がある */
   muted?: boolean
+  /** 音量（0〜1、デフォルト: 1） */
+  volume?: number
 }
 
 /**


### PR DESCRIPTION
## Summary
- VideoScreenコンポーネントに `volume` プロパティを追加
- 0〜1の範囲で音量を調整可能（デフォルト: 1）

## 使い方
```tsx
<VideoScreen
  id="video1"
  url="https://example.com/video.mp4"
  volume={0.5}  // 50%の音量
/>
```

## Test plan
- [ ] VideoScreenでvolume={0.5}を設定して音量が半分になることを確認
- [ ] volumeを動的に変更して即座に反映されることを確認
- [ ] 範囲外の値（負の値、1より大きい値）がクランプされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)