### PR TITLE
fix(ScreenShareDisplay): Meshを常に存在させてvisibleで制御

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.15.7",
+      "version": "0.15.8",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/ScreenShareDisplay/index.tsx
+++ b/src/components/ScreenShareDisplay/index.tsx
@@ -44,28 +44,24 @@ export const ScreenShareDisplay = memo(({
         interactionText={interactionText}
       >
         {/* 背景（映像がない時のみ表示） */}
-        {!hasVideo && (
-          <mesh>
-            <planeGeometry args={[screenSize[0], screenSize[1]]} />
-            <meshBasicMaterial
-              side={THREE.FrontSide}
-              toneMapped={false}
-              color="#1a1a2a"
-            />
-          </mesh>
-        )}
+        <mesh visible={!hasVideo}>
+          <planeGeometry args={[screenSize[0], screenSize[1]]} />
+          <meshBasicMaterial
+            side={THREE.FrontSide}
+            toneMapped={false}
+            color="#1a1a2a"
+          />
+        </mesh>
         {/* 映像 */}
-        {hasVideo && (
-          <mesh>
-            <planeGeometry args={[videoSize[0], videoSize[1]]} />
-            <meshBasicMaterial
-              ref={materialRef}
-              map={texture}
-              side={THREE.FrontSide}
-              toneMapped={false}
-            />
-          </mesh>
-        )}
+        <mesh visible={hasVideo}>
+          <planeGeometry args={[videoSize[0], videoSize[1]]} />
+          <meshBasicMaterial
+            ref={materialRef}
+            map={texture}
+            side={THREE.FrontSide}
+            toneMapped={false}
+          />
+        </mesh>
       </Interactable>
 
       {/* ガイドテキスト */}


### PR DESCRIPTION
## Summary
- 条件付きレンダリング（`{hasVideo && ...}`）から`visible`プロパティによる表示制御に変更
- これにより`Interactable`の子要素が常に存在し、マウント時にレイヤー設定が正しく適用される
- バージョンを0.15.8にbump

## 背景
PR #56 で映像表示中に背景を非表示にする際、Meshの条件付きレンダリングを使用したことで、`Interactable`コンポーネントのレイヤー設定が新しい子要素に適用されなくなっていた。

## Test plan
- [ ] 画面共有開始時にインタラクトできることを確認
- [ ] 映像がない時も背景が表示されインタラクトできることを確認

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)