### PR TITLE
refactor!: User型からsocketIdフィールドを削除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.15.8",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.15.8",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.15.8",
+  "version": "0.16.0",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/contexts/UsersContext.tsx
+++ b/src/contexts/UsersContext.tsx
@@ -5,10 +5,8 @@ import type { PlayerMovement } from '../types/movement'
  * ユーザー情報の型定義
  */
 export interface User {
-  /** 認証ユーザーID */
+  /** ユーザーの一意識別子（userId） */
   id: string
-  /** ソケット接続ID */
-  socketId: string
   /** 表示名 */
   displayName: string
   /** アバターアイコンURL */
@@ -42,10 +40,10 @@ export interface UsersContextValue {
   /**
    * 指定したユーザーの位置情報を取得
    * useFrame内で毎フレーム呼び出しても再レンダリングを引き起こさない
-   * @param socketId - ソケット接続ID
+   * @param userId - ユーザーの一意識別子
    * @returns PlayerMovement または undefined（ユーザーが存在しない場合）
    */
-  getMovement: (socketId: string) => PlayerMovement | undefined
+  getMovement: (userId: string) => PlayerMovement | undefined
   /**
    * ローカルユーザー（自分）の位置情報を取得
    * useFrame内で毎フレーム呼び出しても再レンダリングを引き起こさない
@@ -120,7 +118,7 @@ export const UsersProvider = ({ implementation, children }: Props) => {
  *
  *   // 他のユーザーの位置を取得
  *   remoteUsers.forEach(user => {
- *     const movement = getMovement(user.socketId)
+ *     const movement = getMovement(user.id)
  *     if (movement) {
  *       console.log(`${user.displayName} is at`, movement.position)
  *     }


### PR DESCRIPTION
## Summary
- `User`型から`socketId`フィールドを削除
- `getMovement`の引数を`socketId`から`userId`に変更
- `User.id`のコメントを「ユーザーの一意識別子（userId）」に更新
- ドキュメントの使用例を更新
- バージョンを0.16.0にbump

## BREAKING CHANGE
- `User.socketId`が削除されました。`User.id`を使用してください
- `getMovement(socketId)`は`getMovement(userId)`に変更されました

## 背景
xrift-frontendでプレイヤー識別子を`socketId`から`userId`ベースに変更したため（PR: https://github.com/WebXR-JP/xrift-frontend/pull/599）、コンポーネントライブラリ側も合わせて更新。

## Test plan
- [ ] 型定義の変更が正しく反映されていることを確認
- [ ] xrift-frontendで使用時に型エラーが発生しないことを確認

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)