### PR TITLE
fix(VideoPlayer): 読み込み失敗時もコントロールパネルを表示

### DIFF
--- a/src/components/LiveVideoPlayer/index.tsx
+++ b/src/components/LiveVideoPlayer/index.tsx
@@ -1,5 +1,5 @@
-import { memo, Suspense, useState, useCallback, useEffect, useRef } from 'react'
-import { useVideoTexture } from '@react-three/drei'
+import { memo, Suspense, useState, useCallback, useEffect, useRef, Component, ReactNode } from 'react'
+import { useVideoTexture, Text } from '@react-three/drei'
 import { ControlPanel } from './ControlPanel'
 import type { LiveVideoPlayerProps } from './types'
 
@@ -9,24 +9,59 @@ const DEFAULT_POSITION: [number, number, number] = [0, 2, -5]
 const DEFAULT_ROTATION: [number, number, number] = [0, 0, 0]
 const DEFAULT_WIDTH = 4
 
-const LiveVideoPlayerInner = memo(
+/** エラー境界：子コンポーネントでエラーが発生した場合にfallbackを表示 */
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback: ReactNode
+  onError?: (error: Error) => void
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+class VideoErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error) {
+    console.error('Video load error:', error)
+    this.props.onError?.(error)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback
+    }
+    return this.props.children
+  }
+}
+
+/** 動画テクスチャを表示するコンポーネント（Suspense内で使用） */
+const VideoTexture = memo(
   ({
-    id,
-    position = DEFAULT_POSITION,
-    rotation = DEFAULT_ROTATION,
-    width = DEFAULT_WIDTH,
-    url = '',
-    playing: initialPlaying = true,
-    volume: initialVolume = 1,
+    url,
+    width,
+    screenHeight,
+    playing,
+    volume,
     onError,
-    onUrlChange,
-  }: LiveVideoPlayerProps & { url: string; onUrlChange: (url: string) => void }) => {
-    const [playing, setPlaying] = useState(initialPlaying)
-    const [volume, setVolume] = useState(initialVolume)
-    const [isBuffering, setIsBuffering] = useState(false)
-
-    const screenHeight = width * (9 / 16)
-
+    onBufferingChange,
+  }: {
+    url: string
+    width: number
+    screenHeight: number
+    playing: boolean
+    volume: number
+    onError?: (error: Error) => void
+    onBufferingChange: (isBuffering: boolean) => void
+  }) => {
     const texture = useVideoTexture(url, {
       muted: false,
       loop: false,
@@ -64,9 +99,9 @@ const LiveVideoPlayerInner = memo(
       const video = videoRef.current
       if (!video) return
 
-      const handleWaiting = () => setIsBuffering(true)
-      const handlePlaying = () => setIsBuffering(false)
-      const handleCanPlay = () => setIsBuffering(false)
+      const handleWaiting = () => onBufferingChange(true)
+      const handlePlaying = () => onBufferingChange(false)
+      const handleCanPlay = () => onBufferingChange(false)
       const handleError = (e: Event) => {
         const error = (e.target as HTMLVideoElement).error
         if (error) {
@@ -86,7 +121,7 @@ const LiveVideoPlayerInner = memo(
         video.removeEventListener('canplay', handleCanPlay)
         video.removeEventListener('error', handleError)
       }
-    }, [texture, onError])
+    }, [texture, onError, onBufferingChange])
 
     useEffect(() => {
       const video = texture.image as HTMLVideoElement
@@ -97,41 +132,28 @@ const LiveVideoPlayerInner = memo(
       }
     }, [texture])
 
-    const handlePlayPause = useCallback(() => {
-      setPlaying((prev) => !prev)
-    }, [])
-
-    const handleVolumeChange = useCallback((newVolume: number) => {
-      setVolume(newVolume)
-    }, [])
-
     return (
-      <group position={position} rotation={rotation}>
-        {/* 画面本体 */}
-        <mesh>
-          <planeGeometry args={[width, screenHeight]} />
-          <meshBasicMaterial map={texture} toneMapped={false} />
-        </mesh>
-
-        {/* コントロールパネル */}
-        <ControlPanel
-          id={id}
-          width={width}
-          screenHeight={screenHeight}
-          playing={playing}
-          volume={volume}
-          isBuffering={isBuffering}
-          currentUrl={url}
-          onPlayPause={handlePlayPause}
-          onVolumeChange={handleVolumeChange}
-          onUrlChange={onUrlChange}
-        />
-      </group>
+      <mesh>
+        <planeGeometry args={[width, screenHeight]} />
+        <meshBasicMaterial map={texture} toneMapped={false} />
+      </mesh>
     )
   }
 )
 
-LiveVideoPlayerInner.displayName = 'LiveVideoPlayerInner'
+VideoTexture.displayName = 'VideoTexture'
+
+/** プレースホルダー画面（読み込み中/エラー時/URL未設定時） */
+const PlaceholderScreen = memo(
+  ({ width, screenHeight, color }: { width: number; screenHeight: number; color: string }) => (
+    <mesh>
+      <planeGeometry args={[width, screenHeight]} />
+      <meshBasicMaterial color={color} />
+    </mesh>
+  )
+)
+
+PlaceholderScreen.displayName = 'PlaceholderScreen'
 
 export const LiveVideoPlayer = memo(
   ({
@@ -140,48 +162,96 @@ export const LiveVideoPlayer = memo(
     rotation = DEFAULT_ROTATION,
     width = DEFAULT_WIDTH,
     url: initialUrl,
-    ...props
+    playing: initialPlaying = true,
+    volume: initialVolume = 1,
+    onError,
   }: LiveVideoPlayerProps) => {
     const [currentUrl, setCurrentUrl] = useState(initialUrl)
+    const [playing, setPlaying] = useState(initialPlaying)
+    const [volume, setVolume] = useState(initialVolume)
+    const [isBuffering, setIsBuffering] = useState(false)
+    const [hasError, setHasError] = useState(false)
     const screenHeight = width * (9 / 16)
 
     const handleUrlChange = useCallback((newUrl: string) => {
       setCurrentUrl(newUrl)
+      setHasError(false)
     }, [])
 
-    if (!currentUrl) {
-      return (
-        <group position={position} rotation={rotation}>
-          <mesh>
-            <planeGeometry args={[width, screenHeight]} />
-            <meshBasicMaterial color="#000000" />
-          </mesh>
-        </group>
-      )
-    }
+    const handlePlayPause = useCallback(() => {
+      setPlaying((prev) => !prev)
+    }, [])
+
+    const handleVolumeChange = useCallback((newVolume: number) => {
+      setVolume(newVolume)
+    }, [])
+
+    const handleBufferingChange = useCallback((buffering: boolean) => {
+      setIsBuffering(buffering)
+    }, [])
+
+    const handleError = useCallback(
+      (error: Error) => {
+        setHasError(true)
+        onError?.(error)
+      },
+      [onError]
+    )
 
     return (
-      <Suspense
-        fallback={
-          <group position={position} rotation={rotation}>
-            <mesh>
-              <planeGeometry args={[width, screenHeight]} />
-              <meshBasicMaterial color="#333333" />
-            </mesh>
-          </group>
-        }
-      >
-        <LiveVideoPlayerInner
-          key={currentUrl}
+      <group position={position} rotation={rotation}>
+        {/* 画面本体 */}
+        {!currentUrl || hasError ? (
+          <>
+            <PlaceholderScreen width={width} screenHeight={screenHeight} color="#000000" />
+            {!currentUrl && (
+              <Text
+                position={[0, 0, 0.01]}
+                fontSize={width * 0.05}
+                color="#666666"
+                anchorX="center"
+                anchorY="middle"
+              >
+                URLを入力してください
+              </Text>
+            )}
+          </>
+        ) : (
+          <VideoErrorBoundary
+            fallback={<PlaceholderScreen width={width} screenHeight={screenHeight} color="#000000" />}
+            onError={handleError}
+          >
+            <Suspense
+              fallback={<PlaceholderScreen width={width} screenHeight={screenHeight} color="#333333" />}
+            >
+              <VideoTexture
+                key={currentUrl}
+                url={currentUrl}
+                width={width}
+                screenHeight={screenHeight}
+                playing={playing}
+                volume={volume}
+                onError={handleError}
+                onBufferingChange={handleBufferingChange}
+              />
+            </Suspense>
+          </VideoErrorBoundary>
+        )}
+
+        {/* コントロールパネル（常に表示） */}
+        <ControlPanel
           id={id}
-          position={position}
-          rotation={rotation}
           width={width}
-          url={currentUrl}
+          screenHeight={screenHeight}
+          playing={playing}
+          volume={volume}
+          isBuffering={isBuffering}
+          currentUrl={currentUrl || ''}
+          onPlayPause={handlePlayPause}
+          onVolumeChange={handleVolumeChange}
           onUrlChange={handleUrlChange}
-          {...props}
         />
-      </Suspense>
+      </group>
     )
   }
 )

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -1,5 +1,5 @@
-import { memo, Suspense, useState, useCallback, useEffect, useRef } from 'react'
-import { useVideoTexture } from '@react-three/drei'
+import { memo, Suspense, useState, useCallback, useEffect, useRef, Component, ReactNode } from 'react'
+import { useVideoTexture, Text } from '@react-three/drei'
 import { useFrame } from '@react-three/fiber'
 import { ControlPanel } from './ControlPanel'
 import type { VideoPlayerProps } from './types'
@@ -10,35 +10,70 @@ const DEFAULT_POSITION: [number, number, number] = [0, 2, -5]
 const DEFAULT_ROTATION: [number, number, number] = [0, 0, 0]
 const DEFAULT_WIDTH = 4
 
-const VideoPlayerInner = memo(
+/** エラー境界：子コンポーネントでエラーが発生した場合にfallbackを表示 */
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback: ReactNode
+  onError?: (error: Error) => void
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+class VideoErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error) {
+    console.error('Video load error:', error)
+    this.props.onError?.(error)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback
+    }
+    return this.props.children
+  }
+}
+
+/** 動画テクスチャを表示するコンポーネント（Suspense内で使用） */
+const VideoTexture = memo(
   ({
-    id,
-    position = DEFAULT_POSITION,
-    rotation = DEFAULT_ROTATION,
-    width = DEFAULT_WIDTH,
-    url = '',
-    playing: initialPlaying = true,
-    volume: initialVolume = 1,
-    onUrlChange,
-  }: VideoPlayerProps & { url: string; onUrlChange: (url: string) => void }) => {
-    const [playing, setPlaying] = useState(initialPlaying)
-    const [volume, setVolume] = useState(initialVolume)
-    const [progress, setProgress] = useState(0)
-    const [duration, setDuration] = useState(0)
-
-    const screenHeight = width * (9 / 16)
-
+    url,
+    width,
+    screenHeight,
+    playing,
+    volume,
+    videoRef,
+    onDurationChange,
+    onProgressChange,
+  }: {
+    url: string
+    width: number
+    screenHeight: number
+    playing: boolean
+    volume: number
+    videoRef: React.MutableRefObject<HTMLVideoElement | null>
+    onDurationChange: (duration: number) => void
+    onProgressChange: (progress: number) => void
+  }) => {
     const texture = useVideoTexture(url, {
       muted: false,
       loop: true,
       start: playing,
     })
 
-    const videoRef = useRef<HTMLVideoElement>(texture.image as HTMLVideoElement)
-
     useEffect(() => {
       videoRef.current = texture.image as HTMLVideoElement
-    }, [texture])
+    }, [texture, videoRef])
 
     useEffect(() => {
       const video = videoRef.current
@@ -51,39 +86,39 @@ const VideoPlayerInner = memo(
       } else {
         video.pause()
       }
-    }, [playing])
+    }, [playing, videoRef])
 
     useEffect(() => {
       const video = videoRef.current
       if (!video) return
 
       video.volume = Math.max(0, Math.min(1, volume))
-    }, [volume])
+    }, [volume, videoRef])
 
     useEffect(() => {
       const video = videoRef.current
       if (!video) return
 
       const handleLoadedMetadata = () => {
-        setDuration(video.duration || 0)
+        onDurationChange(video.duration || 0)
       }
 
       if (video.duration) {
-        setDuration(video.duration)
+        onDurationChange(video.duration)
       }
 
       video.addEventListener('loadedmetadata', handleLoadedMetadata)
       return () => {
         video.removeEventListener('loadedmetadata', handleLoadedMetadata)
       }
-    }, [texture])
+    }, [texture, onDurationChange, videoRef])
 
     useFrame(() => {
       const video = videoRef.current
       if (!video || !video.duration) return
 
       const currentProgress = video.currentTime / video.duration
-      setProgress(currentProgress)
+      onProgressChange(currentProgress)
     })
 
     useEffect(() => {
@@ -95,49 +130,28 @@ const VideoPlayerInner = memo(
       }
     }, [texture])
 
-    const handlePlayPause = useCallback(() => {
-      setPlaying((prev) => !prev)
-    }, [])
-
-    const handleSeek = useCallback((time: number) => {
-      const video = videoRef.current
-      if (!video) return
-      video.currentTime = time
-    }, [])
-
-    const handleVolumeChange = useCallback((newVolume: number) => {
-      setVolume(newVolume)
-    }, [])
-
     return (
-      <group position={position} rotation={rotation}>
-        {/* 画面本体 */}
-        <mesh>
-          <planeGeometry args={[width, screenHeight]} />
-          <meshBasicMaterial map={texture} toneMapped={false} />
-        </mesh>
-
-        {/* コントロールパネル */}
-        <ControlPanel
-          id={id}
-          width={width}
-          screenHeight={screenHeight}
-          playing={playing}
-          progress={progress}
-          duration={duration}
-          volume={volume}
-          currentUrl={url}
-          onPlayPause={handlePlayPause}
-          onSeek={handleSeek}
-          onVolumeChange={handleVolumeChange}
-          onUrlChange={onUrlChange}
-        />
-      </group>
+      <mesh>
+        <planeGeometry args={[width, screenHeight]} />
+        <meshBasicMaterial map={texture} toneMapped={false} />
+      </mesh>
     )
   }
 )
 
-VideoPlayerInner.displayName = 'VideoPlayerInner'
+VideoTexture.displayName = 'VideoTexture'
+
+/** プレースホルダー画面（読み込み中/エラー時/URL未設定時） */
+const PlaceholderScreen = memo(
+  ({ width, screenHeight, color }: { width: number; screenHeight: number; color: string }) => (
+    <mesh>
+      <planeGeometry args={[width, screenHeight]} />
+      <meshBasicMaterial color={color} />
+    </mesh>
+  )
+)
+
+PlaceholderScreen.displayName = 'PlaceholderScreen'
 
 export const VideoPlayer = memo(
   ({
@@ -146,48 +160,109 @@ export const VideoPlayer = memo(
     rotation = DEFAULT_ROTATION,
     width = DEFAULT_WIDTH,
     url: initialUrl,
-    ...props
+    playing: initialPlaying = true,
+    volume: initialVolume = 1,
   }: VideoPlayerProps) => {
     const [currentUrl, setCurrentUrl] = useState(initialUrl)
+    const [playing, setPlaying] = useState(initialPlaying)
+    const [volume, setVolume] = useState(initialVolume)
+    const [progress, setProgress] = useState(0)
+    const [duration, setDuration] = useState(0)
+    const [hasError, setHasError] = useState(false)
+    const videoRef = useRef<HTMLVideoElement | null>(null)
     const screenHeight = width * (9 / 16)
 
     const handleUrlChange = useCallback((newUrl: string) => {
       setCurrentUrl(newUrl)
+      setHasError(false)
+      setProgress(0)
+      setDuration(0)
     }, [])
 
-    if (!currentUrl) {
-      return (
-        <group position={position} rotation={rotation}>
-          <mesh>
-            <planeGeometry args={[width, screenHeight]} />
-            <meshBasicMaterial color="#000000" />
-          </mesh>
-        </group>
-      )
-    }
+    const handlePlayPause = useCallback(() => {
+      setPlaying((prev) => !prev)
+    }, [])
+
+    const handleVolumeChange = useCallback((newVolume: number) => {
+      setVolume(newVolume)
+    }, [])
+
+    const handleSeek = useCallback((time: number) => {
+      const video = videoRef.current
+      if (!video) return
+      video.currentTime = time
+    }, [])
+
+    const handleDurationChange = useCallback((newDuration: number) => {
+      setDuration(newDuration)
+    }, [])
+
+    const handleProgressChange = useCallback((newProgress: number) => {
+      setProgress(newProgress)
+    }, [])
+
+    const handleError = useCallback((error: Error) => {
+      console.error('VideoPlayer error:', error)
+      setHasError(true)
+    }, [])
 
     return (
-      <Suspense
-        fallback={
-          <group position={position} rotation={rotation}>
-            <mesh>
-              <planeGeometry args={[width, screenHeight]} />
-              <meshBasicMaterial color="#333333" />
-            </mesh>
-          </group>
-        }
-      >
-        <VideoPlayerInner
-          key={currentUrl}
+      <group position={position} rotation={rotation}>
+        {/* 画面本体 */}
+        {!currentUrl || hasError ? (
+          <>
+            <PlaceholderScreen width={width} screenHeight={screenHeight} color="#000000" />
+            {!currentUrl && (
+              <Text
+                position={[0, 0, 0.01]}
+                fontSize={width * 0.05}
+                color="#666666"
+                anchorX="center"
+                anchorY="middle"
+              >
+                URLを入力してください
+              </Text>
+            )}
+          </>
+        ) : (
+          <VideoErrorBoundary
+            fallback={<PlaceholderScreen width={width} screenHeight={screenHeight} color="#000000" />}
+            onError={handleError}
+          >
+            <Suspense
+              fallback={<PlaceholderScreen width={width} screenHeight={screenHeight} color="#333333" />}
+            >
+              <VideoTexture
+                key={currentUrl}
+                url={currentUrl}
+                width={width}
+                screenHeight={screenHeight}
+                playing={playing}
+                volume={volume}
+                videoRef={videoRef}
+                onDurationChange={handleDurationChange}
+                onProgressChange={handleProgressChange}
+              />
+            </Suspense>
+          </VideoErrorBoundary>
+        )}
+
+        {/* コントロールパネル（常に表示） */}
+        <ControlPanel
           id={id}
-          position={position}
-          rotation={rotation}
           width={width}
-          url={currentUrl}
+          screenHeight={screenHeight}
+          playing={playing}
+          progress={progress}
+          duration={duration}
+          volume={volume}
+          currentUrl={currentUrl || ''}
+          onPlayPause={handlePlayPause}
+          onSeek={handleSeek}
+          onVolumeChange={handleVolumeChange}
           onUrlChange={handleUrlChange}
-          {...props}
         />
-      </Suspense>
+      </group>
     )
   }
 )


### PR DESCRIPTION
## Summary
- `VideoPlayer` と `LiveVideoPlayer` で読み込み失敗時もコントロールパネルを常に表示するよう修正
- `VideoErrorBoundary` を追加してエラーをキャッチ
- URL変更ボタンが常に使えるようになった

## 問題
ライブストリームの読み込みが失敗すると、コントロールパネルが非表示になり、URLを変更できなくなっていた

## 解決策
- コントロールパネルを `Suspense` / `ErrorBoundary` の外に配置
- 画面部分のみ `Suspense` / `ErrorBoundary` でラップ
- エラー状態を管理し、URL変更時にリセット

## Test plan
- [ ] URL未設定時にコントロールパネルが表示されることを確認
- [ ] 読み込み中にコントロールパネルが表示されることを確認
- [ ] 読み込み失敗時にコントロールパネルが表示されることを確認
- [ ] URL変更ボタンから新しいURLを設定できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)