### PR TITLE
fix(LiveVideoPlayer, ScreenShareDisplay): 自動再生とテキスト中央揃えを改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.21.0",
+  "version": "0.21.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.21.0",
+      "version": "0.21.5",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.21.4",
+  "version": "0.21.5",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/LiveVideoPlayer/index.tsx
+++ b/src/components/LiveVideoPlayer/index.tsx
@@ -100,7 +100,7 @@ const VideoTexture = memo(
       } else {
         video.pause();
       }
-    }, [playing, onError]);
+    }, [playing, onError, texture]);
 
     useEffect(() => {
       const video = videoRef.current;
@@ -199,6 +199,9 @@ export const LiveVideoPlayer = memo(
     const handleUrlChange = useCallback((newUrl: string) => {
       setCurrentUrl(newUrl);
       setHasError(false);
+      if (newUrl) {
+        setPlaying(true);
+      }
     }, []);
 
     const handleReload = useCallback(() => {
@@ -243,6 +246,7 @@ export const LiveVideoPlayer = memo(
                 color="#666666"
                 anchorX="center"
                 anchorY="middle"
+                textAlign="center"
               >
                 {`ライブストリームURLを入力\nHLS .m3u8 形式`}
               </Text>

--- a/src/components/ScreenShareDisplay/index.tsx
+++ b/src/components/ScreenShareDisplay/index.tsx
@@ -72,6 +72,7 @@ export const ScreenShareDisplay = memo(({
           color="#666666"
           anchorX="center"
           anchorY="middle"
+          textAlign="center"
         >
           {isRoomConnected ? 'クリックして画面共有' : '他のユーザーがいると\n画面共有できます'}
         </Text>


### PR DESCRIPTION
## Summary
- LiveVideoPlayer: URL入力時に自動再生を開始するよう変更
- LiveVideoPlayer: texture変更時にも再生制御が効くよう依存配列を修正
- LiveVideoPlayer, ScreenShareDisplay: プレースホルダーテキストに`textAlign="center"`を追加
- バージョンを0.21.5に更新

## Test plan
- [ ] LiveVideoPlayerでURLを入力したら自動的に再生が始まることを確認
- [ ] LiveVideoPlayer, ScreenShareDisplayのプレースホルダーテキストが中央揃えになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)