### PR TITLE
fix(VideoPlayer, LiveVideoPlayer): suspend-reactのキャッシュを無効化して再入力エラーを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.21.9",
+  "version": "0.21.10",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/LiveVideoPlayer/index.tsx
+++ b/src/components/LiveVideoPlayer/index.tsx
@@ -60,6 +60,7 @@ class VideoErrorBoundary extends Component<
 const VideoTexture = memo(
   ({
     url,
+    cacheKey,
     width,
     screenHeight,
     playing,
@@ -68,6 +69,7 @@ const VideoTexture = memo(
     onBufferingChange,
   }: {
     url: string;
+    cacheKey: number;
     width: number;
     screenHeight: number;
     playing: boolean;
@@ -75,7 +77,9 @@ const VideoTexture = memo(
     onError?: (error: Error) => void;
     onBufferingChange: (isBuffering: boolean) => void;
   }) => {
-    const texture = useVideoTexture(url, {
+    // suspend-reactのキャッシュを無効化するためにURLにcacheKeyを付与
+    const urlWithCacheKey = `${url}${url.includes("?") ? "&" : "?"}_ck=${cacheKey}`;
+    const texture = useVideoTexture(urlWithCacheKey, {
       muted: false,
       loop: false,
       start: playing,
@@ -275,6 +279,7 @@ export const LiveVideoPlayer = memo(
               <VideoTexture
                 key={`${currentUrl}-${reloadKey}`}
                 url={currentUrl}
+                cacheKey={reloadKey}
                 width={width}
                 screenHeight={screenHeight}
                 playing={playing}

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -49,6 +49,7 @@ class VideoErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryStat
 const VideoTexture = memo(
   ({
     url,
+    cacheKey,
     width,
     screenHeight,
     playing,
@@ -58,6 +59,7 @@ const VideoTexture = memo(
     onProgressChange,
   }: {
     url: string
+    cacheKey: number
     width: number
     screenHeight: number
     playing: boolean
@@ -66,7 +68,9 @@ const VideoTexture = memo(
     onDurationChange: (duration: number) => void
     onProgressChange: (progress: number) => void
   }) => {
-    const texture = useVideoTexture(url, {
+    // suspend-reactのキャッシュを無効化するためにURLにcacheKeyを付与
+    const urlWithCacheKey = `${url}${url.includes('?') ? '&' : '?'}_ck=${cacheKey}`
+    const texture = useVideoTexture(urlWithCacheKey, {
       muted: false,
       loop: true,
       start: playing,
@@ -242,6 +246,7 @@ export const VideoPlayer = memo(
               <VideoTexture
                 key={`${currentUrl}-${reloadKey}`}
                 url={currentUrl}
+                cacheKey={reloadKey}
                 width={width}
                 screenHeight={screenHeight}
                 playing={playing}


### PR DESCRIPTION
## Summary
- VideoPlayer / LiveVideoPlayerで停止後に同じURLを再入力すると発生するエラーを修正
- `useVideoTexture`が使用する`suspend-react`のキャッシュを無効化するため、URLに`_ck`パラメータを付与
- バージョンを0.21.10に更新

## 問題
停止ボタンを押した後、同じURLを再入力すると以下のエラーが発生:
```
NotSupportedError: The element has no supported sources
```

## 原因
`useVideoTexture`は内部で`suspend-react`を使用しており、URLをキャッシュキーとしている。Reactの`key`を変えても、URLが同じならキャッシュから古いvideo要素が返される。その古いvideo要素はcleanup処理で`src=""`になっているためエラー。

## 解決策
`useVideoTexture`に渡すURLにキャッシュバスターパラメータ(`_ck=${reloadKey}`)を追加し、停止→再入力時に新しいvideo要素が作成されるようにした。

## Test plan
- [ ] LiveVideoPlayerでHLS URLを入力して再生
- [ ] 停止ボタンを押す
- [ ] 同じURLを再入力
- [ ] エラーなく再生されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)