### PR TITLE
fix(useWebAudioVolume): AudioContextのクリーンアップを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.21.10",
+  "version": "0.21.11",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/hooks/useWebAudioVolume.ts
+++ b/src/hooks/useWebAudioVolume.ts
@@ -120,10 +120,24 @@ export const useWebAudioVolume = (
     return () => {
       document.removeEventListener('click', handleInteraction)
       document.removeEventListener('touchstart', handleInteraction)
-      // 注意: AudioContextはクローズしない（MediaElementが再利用される可能性があるため）
-      // WeakMapを使用しているので、MediaElementがGCされれば自動的にクリーンアップされる
+
+      // AudioContext のクリーンアップ
+      const connection = audioConnections.get(mediaElement)
+      if (connection) {
+        try {
+          connection.source.disconnect()
+          connection.gainNode.disconnect()
+          connection.audioContext.close().catch(() => {
+            // close 失敗は無視
+          })
+        } catch {
+          // disconnect エラーは無視
+        }
+        audioConnections.delete(mediaElement)
+      }
+      gainNodeRef.current = null
     }
-  }, [mediaElement, volume])
+  }, [mediaElement])
 
   // 音量変更時の処理
   useEffect(() => {


### PR DESCRIPTION
## Summary
- video要素が破棄される際にAudioContextをクローズするように修正
- 停止→再入力を繰り返しても`DEMUXER_ERROR_COULD_NOT_PARSE`エラーが発生しないように
- バージョンを0.21.11に更新

## 問題
停止→再入力を3回以上繰り返すと以下のエラーが発生:
```
PipelineStatus::DEMUXER_ERROR_COULD_NOT_PARSE
```

## 原因
キャッシュバスターにより毎回新しいvideo要素が作成され、それぞれに新しい`AudioContext`が作成されていた。
古い`AudioContext`がクローズされないまま蓄積し、ブラウザのリソース制限に達していた。

## 解決策
`useWebAudioVolume`のcleanup処理で以下を実行:
- `source.disconnect()`
- `gainNode.disconnect()`
- `audioContext.close()`
- WeakMapからエントリを削除

また、依存配列から`volume`を削除し、音量変更時にAudioContextが再作成されないようにした。

## Test plan
- [ ] LiveVideoPlayerでHLS URLを入力して再生
- [ ] 停止ボタンを押す
- [ ] 同じURLを再入力（3回以上繰り返し）
- [ ] エラーなく再生されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)