### PR TITLE
fix(VideoPlayer, LiveVideoPlayer): video要素とテクスチャのクリーンアップを強化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.21.11",
+  "version": "0.21.12",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/LiveVideoPlayer/index.tsx
+++ b/src/components/LiveVideoPlayer/index.tsx
@@ -141,9 +141,19 @@ const VideoTexture = memo(
     useEffect(() => {
       const video = texture.image as HTMLVideoElement;
       return () => {
+        // 再生を停止
         video.pause();
+
+        // ソースを完全にクリア
         video.src = "";
+        video.removeAttribute("src");
+        video.srcObject = null;
+
+        // MediaSourceをリリースするためにloadを呼び出し
         video.load();
+
+        // テクスチャを破棄
+        texture.dispose();
       };
     }, [texture]);
 

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -125,9 +125,19 @@ const VideoTexture = memo(
     useEffect(() => {
       const video = texture.image as HTMLVideoElement
       return () => {
+        // 再生を停止
         video.pause()
+
+        // ソースを完全にクリア
         video.src = ''
+        video.removeAttribute('src')
+        video.srcObject = null
+
+        // MediaSourceをリリースするためにloadを呼び出し
         video.load()
+
+        // テクスチャを破棄
+        texture.dispose()
       }
     }, [texture])
 


### PR DESCRIPTION
## Summary
- video要素とテクスチャのクリーンアップ処理を強化
- 停止→再入力を繰り返した際の`DEMUXER_ERROR_COULD_NOT_PARSE`エラーを軽減
- バージョンを0.21.12に更新

## 変更内容
cleanup処理に以下を追加:
- `video.removeAttribute('src')` - src属性を完全に削除
- `video.srcObject = null` - MediaStreamの参照をクリア
- `texture.dispose()` - Three.jsのテクスチャリソースを解放

## Test plan
- [ ] LiveVideoPlayerでHLS URLを入力して再生
- [ ] 停止ボタンを押す
- [ ] 同じURLを再入力（複数回繰り返し）
- [ ] エラーの発生頻度が減少することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)