### PR TITLE
feat(LiveVideoPlayer): useInstanceStateを使った状態同期を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.21.12",
+  "version": "0.21.13",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/LiveVideoPlayer/types.ts
+++ b/src/components/LiveVideoPlayer/types.ts
@@ -1,3 +1,13 @@
+/** LiveVideoPlayerの同期状態 */
+export interface LiveVideoState {
+  /** 再生中のURL */
+  url?: string
+  /** 再生中かどうか */
+  playing: boolean
+  /** キャッシュバスター用キー */
+  reloadKey: number
+}
+
 export interface LiveVideoPlayerProps {
   /** スクリーンの一意なID（必須） */
   id: string


### PR DESCRIPTION
## Summary
- LiveVideoPlayerにマルチユーザー環境での再生状態の同期機能を追加
- `useInstanceState`フックを使用してURL・再生状態・reloadKeyを同期
- バージョンを0.21.13に更新

## 変更内容

### 同期される状態（`LiveVideoState`）
- `url` - 再生中のストリームURL
- `playing` - 再生/一時停止状態
- `reloadKey` - キャッシュバスター用キー

### ローカルのままの状態
- `volume` - 音量（個人設定）
- `isBuffering` - バッファリング状態
- `hasError` - エラー状態

### 使い方
```tsx
// グローバル同期（デフォルト）
<LiveVideoPlayer id="live-1" />

// ローカルのみ（同期なし）
<LiveVideoPlayer id="live-1" sync="local" />
```

## Test plan
- [ ] 2つのブラウザタブでLiveVideoPlayerを表示
- [ ] 片方でURLを入力して再生
- [ ] もう片方でも同じURLが再生されることを確認
- [ ] 停止操作が同期されることを確認
- [ ] 音量は個別に調整できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)