### PR TITLE
feat(LiveVideoPlayer): Chrome/Firefox で HLS 再生をサポート (hls.js 導入)

### DIFF
--- a/src/components/LiveVideoPlayer/index.tsx
+++ b/src/components/LiveVideoPlayer/index.tsx
@@ -8,10 +8,11 @@ import {
   Component,
   ReactNode,
 } from "react";
-import { useVideoTexture, Text } from "@react-three/drei";
+import { Text } from "@react-three/drei";
 import { ControlPanel } from "./ControlPanel";
 import { useWebAudioVolume } from "../../hooks/useWebAudioVolume";
 import { useInstanceState } from "../../hooks/useInstanceState";
+import { useHlsVideo } from "../../hooks/useHlsVideo";
 import type { LiveVideoPlayerProps, LiveVideoState } from "./types";
 
 export type { LiveVideoPlayerProps, LiveVideoState } from "./types";
@@ -57,11 +58,10 @@ class VideoErrorBoundary extends Component<
   }
 }
 
-/** 動画テクスチャを表示するコンポーネント（Suspense内で使用） */
+/** 動画テクスチャを表示するコンポーネント */
 const VideoTexture = memo(
   ({
     url,
-    cacheKey,
     width,
     screenHeight,
     playing,
@@ -70,7 +70,6 @@ const VideoTexture = memo(
     onBufferingChange,
   }: {
     url: string;
-    cacheKey: number;
     width: number;
     screenHeight: number;
     playing: boolean;
@@ -78,25 +77,30 @@ const VideoTexture = memo(
     onError?: (error: Error) => void;
     onBufferingChange: (isBuffering: boolean) => void;
   }) => {
-    // suspend-reactのキャッシュを無効化するためにURLにcacheKeyを付与
-    const urlWithCacheKey = `${url}${url.includes("?") ? "&" : "?"}_ck=${cacheKey}`;
-    const texture = useVideoTexture(urlWithCacheKey, {
+    // HLS 対応の video とテクスチャを取得
+    const { video, texture, isReady, error } = useHlsVideo(url, {
       muted: false,
       loop: false,
-      start: playing,
+      autoplay: false,
     });
 
-    const videoRef = useRef<HTMLVideoElement>(
-      texture.image as HTMLVideoElement,
-    );
+    const videoRef = useRef<HTMLVideoElement | null>(null);
 
     useEffect(() => {
-      videoRef.current = texture.image as HTMLVideoElement;
-    }, [texture]);
+      videoRef.current = video;
+    }, [video]);
 
+    // エラーをコールバックに伝える
     useEffect(() => {
-      const video = videoRef.current;
-      if (!video) return;
+      if (error) {
+        console.error("HLS video error:", error);
+        onError?.(error);
+      }
+    }, [error, onError]);
+
+    // 再生状態の制御
+    useEffect(() => {
+      if (!video || !isReady) return;
 
       if (playing) {
         video.play().catch((err) => {
@@ -106,23 +110,23 @@ const VideoTexture = memo(
       } else {
         video.pause();
       }
-    }, [playing, onError, texture]);
+    }, [playing, video, isReady, onError]);
 
     // Web Audio API を使用した音量制御（iOS対応）
-    useWebAudioVolume(videoRef.current, volume);
+    useWebAudioVolume(video, volume);
 
+    // バッファリング状態の監視
     useEffect(() => {
-      const video = videoRef.current;
       if (!video) return;
 
       const handleWaiting = () => onBufferingChange(true);
       const handlePlaying = () => onBufferingChange(false);
       const handleCanPlay = () => onBufferingChange(false);
       const handleError = (e: Event) => {
-        const error = (e.target as HTMLVideoElement).error;
-        if (error) {
-          console.error("Live video error:", error.message);
-          onError?.(new Error(error.message));
+        const mediaError = (e.target as HTMLVideoElement).error;
+        if (mediaError) {
+          console.error("Live video error:", mediaError.message);
+          onError?.(new Error(mediaError.message));
         }
       };
 
@@ -137,26 +141,18 @@ const VideoTexture = memo(
         video.removeEventListener("canplay", handleCanPlay);
         video.removeEventListener("error", handleError);
       };
-    }, [texture, onError, onBufferingChange]);
+    }, [video, onError, onBufferingChange]);
 
-    useEffect(() => {
-      const video = texture.image as HTMLVideoElement;
-      return () => {
-        // 再生を停止
-        video.pause();
-
-        // ソースを完全にクリア
-        video.src = "";
-        video.removeAttribute("src");
-        video.srcObject = null;
-
-        // MediaSourceをリリースするためにloadを呼び出し
-        video.load();
-
-        // テクスチャを破棄
-        texture.dispose();
-      };
-    }, [texture]);
+    // テクスチャが準備できていない場合はプレースホルダーを表示
+    if (!texture) {
+      return (
+        <PlaceholderScreen
+          width={width}
+          screenHeight={screenHeight}
+          color="#333333"
+        />
+      );
+    }
 
     return (
       <mesh>
@@ -321,7 +317,6 @@ export const LiveVideoPlayer = memo(
               <VideoTexture
                 key={`${videoState.url}-${videoState.reloadKey}`}
                 url={videoState.url}
-                cacheKey={videoState.reloadKey}
                 width={width}
                 screenHeight={screenHeight}
                 playing={videoState.playing}

--- a/src/hooks/useHlsVideo.ts
+++ b/src/hooks/useHlsVideo.ts
@@ -1,0 +1,269 @@
+import { useEffect, useRef, useState, useMemo } from "react";
+import { VideoTexture, SRGBColorSpace, LinearFilter } from "three";
+
+interface HlsInstance {
+  loadSource(url: string): void;
+  attachMedia(video: HTMLVideoElement): void;
+  destroy(): void;
+  on(event: string, callback: (...args: unknown[]) => void): void;
+  off(event: string, callback: (...args: unknown[]) => void): void;
+}
+
+interface HlsStatic {
+  isSupported(): boolean;
+  Events: {
+    MANIFEST_PARSED: string;
+    ERROR: string;
+  };
+  ErrorTypes: {
+    NETWORK_ERROR: string;
+    MEDIA_ERROR: string;
+  };
+  new (): HlsInstance;
+}
+
+// hls.js の動的インポート用キャッシュ
+let hlsModule: HlsStatic | null = null;
+let hlsModulePromise: Promise<HlsStatic | null> | null = null;
+
+/**
+ * hls.js を動的にインポートする
+ * optional peer dependency なので、インストールされていない場合は null を返す
+ */
+async function loadHls(): Promise<HlsStatic | null> {
+  if (hlsModule !== null) {
+    return hlsModule;
+  }
+
+  if (hlsModulePromise !== null) {
+    return hlsModulePromise;
+  }
+
+  hlsModulePromise = import("hls.js")
+    .then((module) => {
+      hlsModule = module.default as unknown as HlsStatic;
+      return hlsModule;
+    })
+    .catch(() => {
+      console.warn(
+        "hls.js is not installed. HLS playback in Chrome/Firefox will not work.",
+      );
+      return null;
+    });
+
+  return hlsModulePromise;
+}
+
+/**
+ * URL が HLS (.m3u8) かどうかを判定
+ */
+function isHlsUrl(url: string): boolean {
+  const urlLower = url.toLowerCase();
+  // クエリパラメータを除去して拡張子をチェック
+  const pathWithoutQuery = urlLower.split("?")[0];
+  return pathWithoutQuery.endsWith(".m3u8");
+}
+
+/**
+ * ブラウザが HLS をネイティブサポートしているか確認
+ */
+function supportsHlsNatively(): boolean {
+  const video = document.createElement("video");
+  return video.canPlayType("application/vnd.apple.mpegurl") !== "";
+}
+
+interface UseHlsVideoOptions {
+  muted?: boolean;
+  loop?: boolean;
+  autoplay?: boolean;
+  crossOrigin?: string;
+  playsInline?: boolean;
+}
+
+interface UseHlsVideoResult {
+  video: HTMLVideoElement | null;
+  texture: VideoTexture | null;
+  isReady: boolean;
+  error: Error | null;
+}
+
+/**
+ * HLS 対応の video 要素とテクスチャを管理するフック
+ *
+ * - Safari: ネイティブ HLS サポートを使用
+ * - Chrome/Firefox/Edge: hls.js を使用（インストールされている場合）
+ * - 非 HLS URL: 通常の video.src を使用
+ */
+export function useHlsVideo(
+  url: string | undefined,
+  options: UseHlsVideoOptions = {},
+): UseHlsVideoResult {
+  const {
+    muted = false,
+    loop = false,
+    autoplay = false,
+    crossOrigin = "anonymous",
+    playsInline = true,
+  } = options;
+
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const hlsRef = useRef<HlsInstance | null>(null);
+  const textureRef = useRef<VideoTexture | null>(null);
+
+  const [isReady, setIsReady] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // video 要素を作成（一度だけ）
+  const video = useMemo(() => {
+    const v = document.createElement("video");
+    v.muted = muted;
+    v.loop = loop;
+    v.autoplay = autoplay;
+    v.crossOrigin = crossOrigin;
+    v.playsInline = playsInline;
+    v.setAttribute("playsinline", "");
+    v.setAttribute("webkit-playsinline", "");
+    return v;
+  }, [muted, loop, autoplay, crossOrigin, playsInline]);
+
+  // video 参照を更新
+  useEffect(() => {
+    videoRef.current = video;
+  }, [video]);
+
+  // テクスチャを作成
+  const texture = useMemo(() => {
+    const tex = new VideoTexture(video);
+    tex.colorSpace = SRGBColorSpace;
+    tex.minFilter = LinearFilter;
+    tex.magFilter = LinearFilter;
+    textureRef.current = tex;
+    return tex;
+  }, [video]);
+
+  // URL が変更されたときにソースを設定
+  useEffect(() => {
+    if (!url) {
+      setIsReady(false);
+      setError(null);
+      return;
+    }
+
+    setIsReady(false);
+    setError(null);
+
+    const setupVideo = async () => {
+      const isHls = isHlsUrl(url);
+
+      // HLS URL でネイティブサポートがある場合（Safari）
+      if (isHls && supportsHlsNatively()) {
+        video.src = url;
+        return;
+      }
+
+      // HLS URL でネイティブサポートがない場合（Chrome/Firefox/Edge）
+      if (isHls) {
+        const Hls = await loadHls();
+
+        if (!Hls) {
+          setError(
+            new Error(
+              "HLS playback is not supported in this browser. Please install hls.js or use Safari.",
+            ),
+          );
+          return;
+        }
+
+        if (!Hls.isSupported()) {
+          setError(
+            new Error("hls.js is not supported in this browser environment."),
+          );
+          return;
+        }
+
+        // 既存の hls インスタンスを破棄
+        if (hlsRef.current) {
+          hlsRef.current.destroy();
+          hlsRef.current = null;
+        }
+
+        const hls = new Hls();
+        hlsRef.current = hls;
+
+        hls.on(Hls.Events.MANIFEST_PARSED, () => {
+          setIsReady(true);
+        });
+
+        hls.on(Hls.Events.ERROR, (_event: unknown, data: unknown) => {
+          const errorData = data as { fatal?: boolean; type?: string };
+          if (errorData.fatal) {
+            console.error("HLS fatal error:", errorData);
+            setError(new Error(`HLS error: ${errorData.type}`));
+          }
+        });
+
+        hls.loadSource(url);
+        hls.attachMedia(video);
+        return;
+      }
+
+      // 非 HLS URL（通常の動画ファイル）
+      video.src = url;
+    };
+
+    const handleCanPlay = () => {
+      setIsReady(true);
+    };
+
+    const handleError = () => {
+      const mediaError = video.error;
+      if (mediaError) {
+        setError(new Error(`Video error: ${mediaError.message}`));
+      }
+    };
+
+    video.addEventListener("canplay", handleCanPlay);
+    video.addEventListener("error", handleError);
+
+    setupVideo();
+
+    return () => {
+      video.removeEventListener("canplay", handleCanPlay);
+      video.removeEventListener("error", handleError);
+    };
+  }, [url, video]);
+
+  // クリーンアップ
+  useEffect(() => {
+    return () => {
+      // HLS インスタンスを破棄
+      if (hlsRef.current) {
+        hlsRef.current.destroy();
+        hlsRef.current = null;
+      }
+
+      // video をクリーンアップ
+      const v = videoRef.current;
+      if (v) {
+        v.pause();
+        v.src = "";
+        v.removeAttribute("src");
+        v.srcObject = null;
+        v.load();
+      }
+
+      // テクスチャを破棄
+      if (textureRef.current) {
+        textureRef.current.dispose();
+        textureRef.current = null;
+      }
+    };
+  }, []);
+
+  return {
+    video,
+    texture,
+    isReady,
+    error,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,7 @@ export {
 export { useInstanceState } from './hooks/useInstanceState'
 export { useSpawnPoint } from './hooks/useSpawnPoint'
 export { useWebAudioVolume } from './hooks/useWebAudioVolume'
+export { useHlsVideo } from './hooks/useHlsVideo'
 
 // Types
 export {


### PR DESCRIPTION
## Summary
- `useHlsVideo` フックを新規作成し、HLS ストリームの再生を Chrome/Firefox/Edge でもサポート
- Safari はネイティブ HLS サポートを使用し、他のブラウザは hls.js を動的インポート
- `LiveVideoPlayer` の内部実装を `useVideoTexture` から `useHlsVideo` に変更

## 変更内容
- **src/hooks/useHlsVideo.ts** (新規)
  - HLS URL (.m3u8) を自動判定
  - ブラウザのネイティブ HLS サポートを検出
  - hls.js を動的インポート（optional peer dependency）
  - video 要素とテクスチャの作成・クリーンアップを一元管理

- **src/components/LiveVideoPlayer/index.tsx**
  - `useVideoTexture` (drei) から `useHlsVideo` に変更
  - 不要になった `cacheKey` プロパティを削除
  - クリーンアップ処理を `useHlsVideo` に委譲

- **src/index.ts**
  - `useHlsVideo` を export に追加（再利用可能）

## Test plan
- [ ] Safari で HLS ストリームが再生できることを確認
- [ ] Chrome で HLS ストリームが再生できることを確認
- [ ] Firefox で HLS ストリームが再生できることを確認
- [ ] 通常の動画ファイル (mp4等) が再生できることを確認
- [ ] 停止→再入力が正常に動作することを確認

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)