### PR TITLE
feat(Video180Sphere): 180度ステレオスコピック動画を半球に表示するコンポーネントを追加

### DIFF
--- a/src/components/Video180Sphere/EyeView.tsx
+++ b/src/components/Video180Sphere/EyeView.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { BackSide, Color, Mesh, SRGBColorSpace, VideoTexture } from 'three'
+
+interface EyeViewProps {
+  video: HTMLVideoElement
+  eye: 'left' | 'right'
+  radius: number
+  segments: number
+  placeholderColor: string
+}
+
+/**
+ * 各目用のビューを表示する内部コンポーネント
+ * Three.jsのlayersを使用してVR時に左右の目に適切な映像を表示
+ */
+export const EyeView = ({ video, eye, radius, segments, placeholderColor }: EyeViewProps) => {
+  const eyeIndex = eye === 'left' ? 0 : 1
+  const meshRef = useRef<Mesh>(null)
+
+  const texture = useMemo(() => {
+    const tex = new VideoTexture(video)
+    tex.colorSpace = SRGBColorSpace
+    return tex
+  }, [video])
+
+  const placeholderColorVec = useMemo(() => {
+    const color = new Color(placeholderColor)
+    return [color.r, color.g, color.b]
+  }, [placeholderColor])
+
+  useEffect(() => {
+    if (!meshRef.current) return
+    // layer 0 = 通常カメラ（非VR）, layer 1 = 左目, layer 2 = 右目
+    // 左目のメッシュはlayer 0と1に、右目はlayer 2のみ
+    // これにより非VRモードでは左目の映像が見える
+    if (eye === 'left') {
+      meshRef.current.layers.enable(0)
+      meshRef.current.layers.enable(1)
+    } else {
+      meshRef.current.layers.set(2)
+    }
+  }, [eye])
+
+  useEffect(() => {
+    return () => {
+      texture.dispose()
+    }
+  }, [texture])
+
+  // X軸のスケールを反転させて正しい向きのテクスチャを表示
+  // rotation=[0, Math.PI, 0]で180度回転し、前方を向くように調整
+  return (
+    <mesh rotation={[0, Math.PI, 0]} scale={[-1, 1, 1]} ref={meshRef}>
+      <sphereGeometry args={[radius, segments, segments, 0, Math.PI]} />
+      <shaderMaterial
+        uniforms={{
+          map: { value: texture },
+          eyeIndex: { value: eyeIndex },
+          placeholderColor: { value: placeholderColorVec },
+        }}
+        side={BackSide}
+        vertexShader={`
+          varying vec2 vUv;
+          void main() {
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+          }
+        `}
+        fragmentShader={`
+          uniform sampler2D map;
+          uniform int eyeIndex;
+          uniform vec3 placeholderColor;
+          varying vec2 vUv;
+          void main() {
+            vec2 uv = vUv;
+            // Side-by-Side形式のステレオ動画: 左半分が左目、右半分が右目
+            if (eyeIndex == 0) {
+              // 左目: テクスチャの左半分を使用
+              uv.x = uv.x * 0.5;
+            } else {
+              // 右目: テクスチャの右半分を使用
+              uv.x = uv.x * 0.5 + 0.5;
+            }
+            vec4 texColor = texture2D(map, uv);
+            // 動画未読み込み時（黒い画面）はプレースホルダー色を表示
+            float luminance = dot(texColor.rgb, vec3(0.299, 0.587, 0.114));
+            if (luminance < 0.01) {
+              gl_FragColor = vec4(placeholderColor, 1.0);
+              return;
+            }
+            gl_FragColor = texColor;
+          }
+        `}
+      />
+    </mesh>
+  )
+}

--- a/src/components/Video180Sphere/index.tsx
+++ b/src/components/Video180Sphere/index.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useRef, memo } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { EyeView } from './EyeView'
+import { useWebAudioVolume } from '../../hooks/useWebAudioVolume'
+import type { Video180SphereProps } from './types'
+
+export type { Video180SphereProps } from './types'
+
+const DEFAULT_RADIUS = 5
+const DEFAULT_SEGMENTS = 64
+
+/**
+ * 180度ステレオスコピック動画を半球に表示するコンポーネント
+ *
+ * Side-by-Side形式のステレオ動画に対応。
+ * VRモードでは左目と右目に適切な映像を表示する。
+ *
+ * @example
+ * ```tsx
+ * <Video180Sphere
+ *   url="/videos/sample-180-3d.mp4"
+ *   playing={true}
+ *   volume={0.8}
+ * />
+ * ```
+ */
+export const Video180Sphere = memo(
+  ({
+    url,
+    position,
+    rotation,
+    scale,
+    playing = false,
+    muted = false,
+    volume = 1,
+    radius = DEFAULT_RADIUS,
+    segments = DEFAULT_SEGMENTS,
+    loop = false,
+    placeholderColor = '#000000',
+    onEnded,
+    onLoadedMetadata,
+    onProgress,
+  }: Video180SphereProps) => {
+    const videoRef = useRef<HTMLVideoElement | null>(null)
+
+    const video = useMemo(() => {
+      const vid = document.createElement('video')
+      vid.src = url
+      vid.currentTime = 0
+      vid.loop = loop
+      vid.muted = muted
+      vid.crossOrigin = 'anonymous'
+      vid.playsInline = true
+      return vid
+    }, [url, loop, muted])
+
+    // videoRefを更新
+    useEffect(() => {
+      videoRef.current = video
+    }, [video])
+
+    // イベントハンドラの設定
+    useEffect(() => {
+      const handleEnded = () => {
+        onEnded?.()
+      }
+
+      const handleLoadedMetadata = () => {
+        onLoadedMetadata?.({ duration: video.duration })
+      }
+
+      const handleTimeUpdate = () => {
+        onProgress?.({ currentTime: video.currentTime })
+      }
+
+      video.addEventListener('ended', handleEnded)
+      video.addEventListener('loadedmetadata', handleLoadedMetadata)
+      video.addEventListener('timeupdate', handleTimeUpdate)
+
+      return () => {
+        video.removeEventListener('ended', handleEnded)
+        video.removeEventListener('loadedmetadata', handleLoadedMetadata)
+        video.removeEventListener('timeupdate', handleTimeUpdate)
+      }
+    }, [video, onEnded, onLoadedMetadata, onProgress])
+
+    // 再生/停止の制御
+    useEffect(() => {
+      if (playing) {
+        video.play().catch((err) => {
+          console.error('Video play error:', err)
+        })
+      } else {
+        video.pause()
+      }
+    }, [video, playing])
+
+    // Web Audio API を使用した音量制御（iOS対応）
+    useWebAudioVolume(videoRef.current, volume)
+
+    // クリーンアップ
+    useEffect(() => {
+      return () => {
+        video.pause()
+        video.src = ''
+        video.removeAttribute('src')
+        video.srcObject = null
+        video.load()
+      }
+    }, [video])
+
+    // カメラのlayers設定（@react-three/xrのバグ対策）
+    // https://github.com/pmndrs/xr/issues/398
+    useFrame(({ camera }) => {
+      camera.layers.set(0)
+    })
+
+    return (
+      <group position={position} rotation={rotation} scale={scale}>
+        <EyeView video={video} eye="left" radius={radius} segments={segments} placeholderColor={placeholderColor} />
+        <EyeView video={video} eye="right" radius={radius} segments={segments} placeholderColor={placeholderColor} />
+      </group>
+    )
+  }
+)
+
+Video180Sphere.displayName = 'Video180Sphere'

--- a/src/components/Video180Sphere/types.ts
+++ b/src/components/Video180Sphere/types.ts
@@ -1,0 +1,30 @@
+export interface Video180SphereProps {
+  /** 動画のURL */
+  url: string
+  /** 位置 */
+  position?: [number, number, number]
+  /** 回転 */
+  rotation?: [number, number, number]
+  /** スケール */
+  scale?: number | [number, number, number]
+  /** 再生状態 */
+  playing?: boolean
+  /** ミュート状態（trueにするとブラウザの自動再生制限を回避できる） */
+  muted?: boolean
+  /** 音量 (0-1) */
+  volume?: number
+  /** 半球の半径 */
+  radius?: number
+  /** ジオメトリの解像度（セグメント数） */
+  segments?: number
+  /** ループ再生するか */
+  loop?: boolean
+  /** プレースホルダーの色（動画読み込み前に表示、デフォルト: 黒） */
+  placeholderColor?: string
+  /** 動画終了時のコールバック */
+  onEnded?: () => void
+  /** メタデータ読み込み時のコールバック */
+  onLoadedMetadata?: (event: { duration: number }) => void
+  /** 再生進捗更新時のコールバック */
+  onProgress?: (event: { currentTime: number }) => void
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,11 @@ export {
   type Tag,
 } from './components/TagBoard'
 
+export {
+  Video180Sphere,
+  type Video180SphereProps,
+} from './components/Video180Sphere'
+
 // Hooks
 export { useInstanceState } from './hooks/useInstanceState'
 export { useSpawnPoint } from './hooks/useSpawnPoint'

--- a/src/scenes/TestScene.tsx
+++ b/src/scenes/TestScene.tsx
@@ -5,6 +5,7 @@ import { Mirror } from "../components/Mirror";
 import { Skybox } from "../components/Skybox";
 import { TextInput } from "../components/TextInput";
 import { TagBoard } from "../components/TagBoard";
+import { Video180Sphere } from "../components/Video180Sphere";
 
 /**
  * VideoScreenとMirrorのテストシーン
@@ -114,6 +115,15 @@ export function TestScene() {
         instanceStateKey="test-tags"
         position={[0, 2, 7]}
         rotation={[0, Math.PI, 0]}
+      />
+
+      {/* 180度ステレオ動画プレイヤー */}
+      <Video180Sphere
+        url="https://pub-840983ee6395495eb67c382a4ff6214f.r2.dev/chapter01.mp4"
+        position={[3.52, 1.25, 0]}
+        playing
+        muted
+        radius={1} rotation={[0, -1.4660765716752375, 0]}
       />
     </>
   );


### PR DESCRIPTION
## Summary
- 180度ステレオスコピック動画を半球に表示する`Video180Sphere`コンポーネントを追加
- Side-by-Side形式のステレオ動画に対応
- VRモードでは左目/右目に適切な映像を表示、非VRモードでも視聴可能

## Props
| Prop | 型 | デフォルト | 説明 |
|------|---|----------|------|
| `url` | string | 必須 | 動画URL |
| `position` | [number, number, number] | - | 位置 |
| `rotation` | [number, number, number] | - | 回転 |
| `scale` | number \| [number, number, number] | - | スケール |
| `playing` | boolean | false | 再生状態 |
| `muted` | boolean | false | ミュート状態 |
| `volume` | number | 1 | 音量 (0-1) |
| `radius` | number | 5 | 半球の半径 |
| `segments` | number | 64 | ジオメトリ解像度 |
| `loop` | boolean | false | ループ再生 |
| `placeholderColor` | string | #000000 | プレースホルダー色 |

## Test plan
- [x] `npm run build` でビルド成功
- [x] `npm run test` でテスト通過
- [ ] TestSceneで動画が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)