### PR TITLE
feat(Live180Sphere): HLS対応の180度ステレオライブ動画コンポーネントを追加

### DIFF
--- a/src/components/Live180Sphere/EyeView.tsx
+++ b/src/components/Live180Sphere/EyeView.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { BackSide, Color, Mesh, Texture } from 'three'
+
+interface EyeViewProps {
+  texture: Texture
+  eye: 'left' | 'right'
+  radius: number
+  segments: number
+  placeholderColor: string
+}
+
+/**
+ * 各目用のビューを表示する内部コンポーネント
+ * Three.jsのlayersを使用してVR時に左右の目に適切な映像を表示
+ */
+export const EyeView = ({ texture, eye, radius, segments, placeholderColor }: EyeViewProps) => {
+  const eyeIndex = eye === 'left' ? 0 : 1
+  const meshRef = useRef<Mesh>(null)
+
+  const placeholderColorVec = useMemo(() => {
+    const color = new Color(placeholderColor)
+    return [color.r, color.g, color.b]
+  }, [placeholderColor])
+
+  useEffect(() => {
+    if (!meshRef.current) return
+    // layer 0 = 通常カメラ（非VR）, layer 1 = 左目, layer 2 = 右目
+    // 左目のメッシュはlayer 0と1に、右目はlayer 2のみ
+    // これにより非VRモードでは左目の映像が見える
+    if (eye === 'left') {
+      meshRef.current.layers.enable(0)
+      meshRef.current.layers.enable(1)
+    } else {
+      meshRef.current.layers.set(2)
+    }
+  }, [eye])
+
+  // X軸のスケールを反転させて正しい向きのテクスチャを表示
+  // rotation=[0, Math.PI, 0]で180度回転し、前方を向くように調整
+  return (
+    <mesh rotation={[0, Math.PI, 0]} scale={[-1, 1, 1]} ref={meshRef}>
+      <sphereGeometry args={[radius, segments, segments, 0, Math.PI]} />
+      <shaderMaterial
+        uniforms={{
+          map: { value: texture },
+          eyeIndex: { value: eyeIndex },
+          placeholderColor: { value: placeholderColorVec },
+        }}
+        side={BackSide}
+        vertexShader={`
+          varying vec2 vUv;
+          void main() {
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+          }
+        `}
+        fragmentShader={`
+          uniform sampler2D map;
+          uniform int eyeIndex;
+          uniform vec3 placeholderColor;
+          varying vec2 vUv;
+          void main() {
+            vec2 uv = vUv;
+            // Side-by-Side形式のステレオ動画: 左半分が左目、右半分が右目
+            if (eyeIndex == 0) {
+              // 左目: テクスチャの左半分を使用
+              uv.x = uv.x * 0.5;
+            } else {
+              // 右目: テクスチャの右半分を使用
+              uv.x = uv.x * 0.5 + 0.5;
+            }
+            vec4 texColor = texture2D(map, uv);
+            // 動画未読み込み時（黒い画面）はプレースホルダー色を表示
+            float luminance = dot(texColor.rgb, vec3(0.299, 0.587, 0.114));
+            if (luminance < 0.01) {
+              gl_FragColor = vec4(placeholderColor, 1.0);
+              return;
+            }
+            gl_FragColor = texColor;
+          }
+        `}
+      />
+    </mesh>
+  )
+}

--- a/src/components/Live180Sphere/index.tsx
+++ b/src/components/Live180Sphere/index.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef, memo, Suspense } from 'react'
+import { useFrame } from '@react-three/fiber'
+import { useVideoTexture } from '@react-three/drei'
+import { EyeView } from './EyeView'
+import { useWebAudioVolume } from '../../hooks/useWebAudioVolume'
+import type { Live180SphereProps } from './types'
+
+export type { Live180SphereProps } from './types'
+
+const DEFAULT_RADIUS = 5
+const DEFAULT_SEGMENTS = 64
+
+/** プレースホルダー半球（読み込み中に表示） */
+const PlaceholderSphere = memo(
+  ({ radius, segments, color }: { radius: number; segments: number; color: string }) => (
+    <mesh rotation={[0, Math.PI, 0]} scale={[-1, 1, 1]}>
+      <sphereGeometry args={[radius, segments, segments, 0, Math.PI]} />
+      <meshBasicMaterial color={color} side={2} />
+    </mesh>
+  )
+)
+
+PlaceholderSphere.displayName = 'PlaceholderSphere'
+
+/** ライブ動画テクスチャを半球に表示するコンポーネント */
+const LiveVideoSphere = memo(
+  ({
+    url,
+    playing,
+    muted,
+    volume,
+    radius,
+    segments,
+    placeholderColor,
+    onError,
+    onBufferingChange,
+  }: {
+    url: string
+    playing: boolean
+    muted: boolean
+    volume: number
+    radius: number
+    segments: number
+    placeholderColor: string
+    onError?: (error: Error) => void
+    onBufferingChange?: (isBuffering: boolean) => void
+  }) => {
+    const texture = useVideoTexture(url, {
+      muted,
+      loop: false,
+      start: playing,
+    })
+
+    const videoRef = useRef<HTMLVideoElement>(texture.image as HTMLVideoElement)
+
+    useEffect(() => {
+      videoRef.current = texture.image as HTMLVideoElement
+    }, [texture])
+
+    useEffect(() => {
+      const video = videoRef.current
+      if (!video) return
+
+      if (playing) {
+        video.play().catch((err) => {
+          console.error('Live 180 video play error:', err)
+          onError?.(err)
+        })
+      } else {
+        video.pause()
+      }
+    }, [playing, onError, texture])
+
+    // Web Audio API を使用した音量制御（iOS対応）
+    useWebAudioVolume(videoRef.current, volume)
+
+    // バッファリング状態の監視
+    useEffect(() => {
+      const video = videoRef.current
+      if (!video) return
+
+      const handleWaiting = () => onBufferingChange?.(true)
+      const handlePlaying = () => onBufferingChange?.(false)
+      const handleCanPlay = () => onBufferingChange?.(false)
+      const handleError = (e: Event) => {
+        const error = (e.target as HTMLVideoElement).error
+        if (error) {
+          console.error('Live 180 video error:', error.message)
+          onError?.(new Error(error.message))
+        }
+      }
+
+      video.addEventListener('waiting', handleWaiting)
+      video.addEventListener('playing', handlePlaying)
+      video.addEventListener('canplay', handleCanPlay)
+      video.addEventListener('error', handleError)
+
+      return () => {
+        video.removeEventListener('waiting', handleWaiting)
+        video.removeEventListener('playing', handlePlaying)
+        video.removeEventListener('canplay', handleCanPlay)
+        video.removeEventListener('error', handleError)
+      }
+    }, [texture, onError, onBufferingChange])
+
+    // クリーンアップ
+    useEffect(() => {
+      const video = texture.image as HTMLVideoElement
+      return () => {
+        video.pause()
+        video.src = ''
+        video.removeAttribute('src')
+        video.srcObject = null
+        video.load()
+        texture.dispose()
+      }
+    }, [texture])
+
+    return (
+      <>
+        <EyeView texture={texture} eye="left" radius={radius} segments={segments} placeholderColor={placeholderColor} />
+        <EyeView texture={texture} eye="right" radius={radius} segments={segments} placeholderColor={placeholderColor} />
+      </>
+    )
+  }
+)
+
+LiveVideoSphere.displayName = 'LiveVideoSphere'
+
+/**
+ * 180度ステレオスコピックライブ動画を半球に表示するコンポーネント
+ *
+ * HLS（.m3u8）形式のライブストリームに対応。
+ * Side-by-Side形式のステレオ動画に対応し、
+ * VRモードでは左目と右目に適切な映像を表示する。
+ *
+ * @example
+ * ```tsx
+ * <Live180Sphere
+ *   url="https://example.com/live-stream.m3u8"
+ *   playing={true}
+ *   muted
+ * />
+ * ```
+ */
+export const Live180Sphere = memo(
+  ({
+    url,
+    position,
+    rotation,
+    scale,
+    playing = false,
+    muted = false,
+    volume = 1,
+    radius = DEFAULT_RADIUS,
+    segments = DEFAULT_SEGMENTS,
+    placeholderColor = '#000000',
+    onError,
+    onBufferingChange,
+  }: Live180SphereProps) => {
+    // カメラのlayers設定（@react-three/xrのバグ対策）
+    // https://github.com/pmndrs/xr/issues/398
+    useFrame(({ camera }) => {
+      camera.layers.set(0)
+    })
+
+    return (
+      <group position={position} rotation={rotation} scale={scale}>
+        <Suspense fallback={<PlaceholderSphere radius={radius} segments={segments} color={placeholderColor} />}>
+          <LiveVideoSphere
+            url={url}
+            playing={playing}
+            muted={muted}
+            volume={volume}
+            radius={radius}
+            segments={segments}
+            placeholderColor={placeholderColor}
+            onError={onError}
+            onBufferingChange={onBufferingChange}
+          />
+        </Suspense>
+      </group>
+    )
+  }
+)
+
+Live180Sphere.displayName = 'Live180Sphere'

--- a/src/components/Live180Sphere/types.ts
+++ b/src/components/Live180Sphere/types.ts
@@ -1,0 +1,26 @@
+export interface Live180SphereProps {
+  /** ライブストリームのURL（HLS .m3u8形式） */
+  url: string
+  /** 位置 */
+  position?: [number, number, number]
+  /** 回転 */
+  rotation?: [number, number, number]
+  /** スケール */
+  scale?: number | [number, number, number]
+  /** 再生状態 */
+  playing?: boolean
+  /** ミュート状態（trueにするとブラウザの自動再生制限を回避できる） */
+  muted?: boolean
+  /** 音量 (0-1) */
+  volume?: number
+  /** 半球の半径 */
+  radius?: number
+  /** ジオメトリの解像度（セグメント数） */
+  segments?: number
+  /** プレースホルダーの色（動画読み込み前に表示、デフォルト: 黒） */
+  placeholderColor?: string
+  /** エラー時のコールバック */
+  onError?: (error: Error) => void
+  /** バッファリング状態変更時のコールバック */
+  onBufferingChange?: (isBuffering: boolean) => void
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,11 @@ export {
   type Video180SphereProps,
 } from './components/Video180Sphere'
 
+export {
+  Live180Sphere,
+  type Live180SphereProps,
+} from './components/Live180Sphere'
+
 // Hooks
 export { useInstanceState } from './hooks/useInstanceState'
 export { useSpawnPoint } from './hooks/useSpawnPoint'

--- a/src/scenes/TestScene.tsx
+++ b/src/scenes/TestScene.tsx
@@ -6,6 +6,7 @@ import { Skybox } from "../components/Skybox";
 import { TextInput } from "../components/TextInput";
 import { TagBoard } from "../components/TagBoard";
 import { Video180Sphere } from "../components/Video180Sphere";
+import { Live180Sphere } from "../components/Live180Sphere";
 
 /**
  * VideoScreenとMirrorのテストシーン
@@ -123,8 +124,19 @@ export function TestScene() {
         position={[3.52, 1.25, 0]}
         playing
         muted
-        radius={1} rotation={[0, -1.4660765716752375, 0]}
+        radius={1}
+        rotation={[0, -1.4660765716752375, 0]}
       />
+
+      {/* 180度ライブストリームプレイヤー（コメントアウト：HLSストリームのURLが必要） */}
+      {/* <Live180Sphere
+        url="YOUR_HLS_STREAM_URL.m3u8"
+        position={[-3.52, 1.25, 0]}
+        playing
+        muted
+        radius={1}
+        rotation={[0, 1.4660765716752375, 0]}
+      /> */}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- HLS (.m3u8) 対応の180度ステレオライブ動画コンポーネント`Live180Sphere`を追加
- `Video180Sphere`のLive版として、同じインターフェースで使用可能
- Side-by-Side形式のステレオ動画をVR/非VRモードで視聴可能

## Props
| Prop | 型 | デフォルト | 説明 |
|------|---|----------|------|
| `url` | string | 必須 | HLSストリームURL (.m3u8) |
| `position` | [number, number, number] | - | 位置 |
| `rotation` | [number, number, number] | - | 回転 |
| `scale` | number \| [number, number, number] | - | スケール |
| `playing` | boolean | false | 再生状態 |
| `muted` | boolean | false | ミュート状態 |
| `volume` | number | 1 | 音量 (0-1) |
| `radius` | number | 5 | 半球の半径 |
| `placeholderColor` | string | #000000 | プレースホルダー色 |
| `onError` | (error) => void | - | エラーコールバック |
| `onBufferingChange` | (isBuffering) => void | - | バッファリング状態コールバック |

## Test plan
- [x] `npm run build` でビルド成功
- [x] `npm run test` でテスト通過
- [ ] HLSストリームで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)