### PR TITLE
fix: peerDependenciesの@react-three/rapierバージョンを^2.0.0に修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- `peerDependencies` の `@react-three/rapier` を `^1.0.0` → `^2.0.0` に修正
- `xrift-world-template` が使用する `@react-three/rapier@^2.2.0` とのコンフリクトを解消

## Test plan

- [x] `npm run build` 成功
- [x] `npm run test` 全112件パス

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)