### PR TITLE
fix(TagBoard): TagDisplayの頭上タグ表示位置を1m上に調整

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/TagBoard/components/TagDisplay/index.tsx
+++ b/src/components/TagBoard/components/TagDisplay/index.tsx
@@ -25,7 +25,7 @@ import {
   groupTagsByColumn,
 } from "./utils";
 
-const HEAD_OFFSET_Y = 1.6;
+const HEAD_OFFSET_Y = 2.6;
 
 export const TagDisplay = ({
   userId,


### PR DESCRIPTION
## Summary
- TagDisplayの`HEAD_OFFSET_Y`を1.6から2.6に変更し、頭上タグの表示位置を1m上に調整
- パッチバージョンを0.25.0 → 0.25.1に更新

## Test plan
- [ ] TagBoardコンポーネントでタグ選択後、頭上表示が以前より1m上に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)