### PR TITLE
feat: TeleportContext + useTeleport フックの追加

### DIFF
--- a/src/contexts/TeleportContext.tsx
+++ b/src/contexts/TeleportContext.tsx
@@ -1,0 +1,50 @@
+import { createContext, type ReactNode, useContext } from 'react'
+
+export interface TeleportDestination {
+  position: [number, number, number]
+  /** 度数法（0-360）省略時は現在の向きを維持 */
+  yaw?: number
+}
+
+export interface TeleportContextValue {
+  teleport: (destination: TeleportDestination) => void
+}
+
+/**
+ * 開発環境用のデフォルト実装（console.log のみ）
+ * プラットフォーム側が実装を注入しない場合に使用される
+ */
+export const createDefaultTeleportImplementation = (): TeleportContextValue => ({
+  teleport: (destination) =>
+    console.log('[Teleport] teleport called', destination),
+})
+
+/**
+ * テレポート機能を提供する Context
+ * xrift-frontend 側で実装を注入し、ワールド側で利用できる
+ */
+export const TeleportContext = createContext<TeleportContextValue | null>(null)
+
+interface Props {
+  value: TeleportContextValue
+  children: ReactNode
+}
+
+/**
+ * テレポート機能を提供する ContextProvider
+ */
+export const TeleportProvider = ({ value, children }: Props) => {
+  return <TeleportContext.Provider value={value}>{children}</TeleportContext.Provider>
+}
+
+/**
+ * テレポートの Context を取得する hook
+ * @throws {Error} TeleportProvider の外で呼び出された場合
+ */
+export const useTeleportContext = (): TeleportContextValue => {
+  const context = useContext(TeleportContext)
+  if (!context) {
+    throw new Error('useTeleportContext must be used within TeleportProvider')
+  }
+  return context
+}

--- a/src/contexts/XRiftContext.tsx
+++ b/src/contexts/XRiftContext.tsx
@@ -4,6 +4,11 @@ import { InstanceStateProvider, type InstanceStateContextValue } from './Instanc
 import { ScreenShareProvider, type ScreenShareContextValue } from './ScreenShareContext'
 import { SpawnPointProvider, type SpawnPointContextValue } from './SpawnPointContext'
 import {
+  TeleportProvider,
+  createDefaultTeleportImplementation,
+  type TeleportContextValue,
+} from './TeleportContext'
+import {
   TextInputProvider,
   createDefaultTextInputImplementation,
   type TextInputContextValue,
@@ -73,6 +78,11 @@ interface Props {
    */
   spawnPointImplementation?: SpawnPointContextValue
   /**
+   * テレポート機能の実装（オプション）
+   * 指定しない場合はデフォルト実装（console.log）が使用される
+   */
+  teleportImplementation?: TeleportContextValue
+  /**
    * テキスト入力の実装（オプション）
    * 指定しない場合はデフォルト実装（ブラウザのprompt）が使用される
    */
@@ -100,6 +110,7 @@ export const XRiftProvider = ({
   instanceStateImplementation,
   screenShareImplementation,
   spawnPointImplementation,
+  teleportImplementation,
   textInputImplementation,
   usersImplementation,
   worldEventImplementation,
@@ -118,6 +129,12 @@ export const XRiftProvider = ({
   const textInputImpl = useMemo(
     () => textInputImplementation ?? createDefaultTextInputImplementation(),
     [textInputImplementation],
+  )
+
+  // テレポートの実装（指定がない場合はデフォルト実装を使用）
+  const teleportImpl = useMemo(
+    () => teleportImplementation ?? createDefaultTeleportImplementation(),
+    [teleportImplementation],
   )
 
   // ワールドイベントの実装（指定がない場合はデフォルト実装を使用）
@@ -151,7 +168,9 @@ export const XRiftProvider = ({
             <SpawnPointProvider implementation={spawnPointImplementation}>
               <UsersProvider implementation={usersImplementation}>
                 <WorldEventProvider value={worldEventImpl}>
-                  {children}
+                  <TeleportProvider value={teleportImpl}>
+                    {children}
+                  </TeleportProvider>
                 </WorldEventProvider>
               </UsersProvider>
             </SpawnPointProvider>

--- a/src/hooks/useTeleport.ts
+++ b/src/hooks/useTeleport.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react'
+import { type TeleportDestination, useTeleportContext } from '../contexts/TeleportContext'
+
+/**
+ * テレポート機能を使用するhook
+ * ワールド作成者がプレイヤーを瞬間移動させるために使用
+ *
+ * @example
+ * const { teleport } = useTeleport()
+ *
+ * // 位置と向きを指定してテレポート
+ * teleport({ position: [50, 0, 30], yaw: 180 })
+ *
+ * // 向きは省略可能（現在の向きを維持）
+ * teleport({ position: [50, 0, 30] })
+ *
+ * @returns {{ teleport: (destination: TeleportDestination) => void }}
+ */
+export const useTeleport = (): { teleport: (destination: TeleportDestination) => void } => {
+  const { teleport } = useTeleportContext()
+
+  const stableTeleport = useCallback(
+    (destination: TeleportDestination) => {
+      teleport(destination)
+    },
+    [teleport],
+  )
+
+  return { teleport: stableTeleport }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,15 @@ export {
 } from './contexts/TextInputContext'
 
 export {
+  TeleportContext,
+  TeleportProvider,
+  useTeleportContext,
+  createDefaultTeleportImplementation,
+  type TeleportContextValue,
+  type TeleportDestination,
+} from './contexts/TeleportContext'
+
+export {
   WorldEventContext,
   WorldEventProvider,
   useWorldEventContext,
@@ -113,6 +122,7 @@ export { type PhysicsConfig } from './components/DevEnvironment/types'
 // Hooks
 export { useInstanceState } from './hooks/useInstanceState'
 export { useSpawnPoint } from './hooks/useSpawnPoint'
+export { useTeleport } from './hooks/useTeleport'
 export { useWebAudioVolume } from './hooks/useWebAudioVolume'
 export { useWorldEvent } from './hooks/useWorldEvent'
 


### PR DESCRIPTION
## Summary

- ワールド作成者がプレイヤーを瞬間移動させるテレポートAPIを追加
- `TeleportContext` + `TeleportProvider` + `useTeleportContext` を新規作成
- ワールド作成者向け公開フック `useTeleport` を新規作成
- `XRiftProvider` に `teleportImplementation` props を追加し、`TeleportProvider` をネスト
- 開発環境用のデフォルト実装 `createDefaultTeleportImplementation` を提供

## ワールド作成者向けAPI

```tsx
const { teleport } = useTeleport()

// 位置と向きを指定してテレポート
teleport({ position: [50, 0, 30], yaw: 180 })

// 向きは省略可能（現在の向きを維持）
teleport({ position: [50, 0, 30] })
```

## xrift-frontend 側との連携

xrift-frontend PR #790 の `useTeleportImplementation` が返す `{ teleport }` を `XRiftProvider` の `teleportImplementation` に渡すことで統合される。

Closes #107

## Test plan

- [x] TypeScript 型チェック通過
- [x] 全テスト通過（15スイート / 162テスト）
- [ ] xrift-frontend PR #790 との手動統合テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)