### PR TITLE
chore: bump version to 0.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- TeleportContext + useTeleport フックの追加に伴うマイナーバージョンアップ
- `0.25.1` → `0.26.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)