### PR TITLE
chore: bump version to 0.26.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- TeleportContext を含む正しい状態で再パブリッシュするためのパッチバージョンアップ
- `0.26.0` → `0.26.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)