### PR TITLE
feat: Portal コンポーネントと ConfirmContext の追加

### DIFF
--- a/src/components/Portal/__tests__/utils.test.ts
+++ b/src/components/Portal/__tests__/utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { generateParticlePositions, generateParticleVelocities } from '../utils'
+
+describe('generateParticlePositions', () => {
+  it('正しい長さのFloat32Arrayを返す', () => {
+    const result = generateParticlePositions(80, 1.0, 1.3)
+    expect(result).toBeInstanceOf(Float32Array)
+    expect(result.length).toBe(80 * 3)
+  })
+
+  it('パーティクル数0で空の配列を返す', () => {
+    const result = generateParticlePositions(0, 1.0, 1.3)
+    expect(result.length).toBe(0)
+  })
+
+  it('各パーティクルのXY座標が半径内に収まる', () => {
+    const radius = 1.0
+    const aspectRatio = 1.3
+    const result = generateParticlePositions(100, radius, aspectRatio)
+
+    for (let i = 0; i < 100; i++) {
+      const x = result[i * 3]
+      const y = result[i * 3 + 1]
+      expect(Math.abs(x)).toBeLessThanOrEqual(radius)
+      expect(Math.abs(y)).toBeLessThanOrEqual(radius * aspectRatio)
+    }
+  })
+
+  it('Z座標が-0.1〜0.1の範囲内に収まる', () => {
+    const result = generateParticlePositions(100, 1.0, 1.3)
+
+    for (let i = 0; i < 100; i++) {
+      const z = result[i * 3 + 2]
+      expect(z).toBeGreaterThanOrEqual(-0.1)
+      expect(z).toBeLessThanOrEqual(0.1)
+    }
+  })
+})
+
+describe('generateParticleVelocities', () => {
+  it('正しい長さのFloat32Arrayを返す', () => {
+    const result = generateParticleVelocities(80)
+    expect(result).toBeInstanceOf(Float32Array)
+    expect(result.length).toBe(80 * 2)
+  })
+
+  it('角速度が0.5〜2.0の範囲内', () => {
+    const result = generateParticleVelocities(100)
+
+    for (let i = 0; i < 100; i++) {
+      const angularSpeed = result[i * 2]
+      expect(angularSpeed).toBeGreaterThanOrEqual(0.5)
+      expect(angularSpeed).toBeLessThanOrEqual(2.0)
+    }
+  })
+
+  it('初期位相が0〜2πの範囲内', () => {
+    const result = generateParticleVelocities(100)
+
+    for (let i = 0; i < 100; i++) {
+      const phase = result[i * 2 + 1]
+      expect(phase).toBeGreaterThanOrEqual(0)
+      expect(phase).toBeLessThanOrEqual(Math.PI * 2)
+    }
+  })
+})

--- a/src/components/Portal/components/PortalGlow/index.tsx
+++ b/src/components/Portal/components/PortalGlow/index.tsx
@@ -1,0 +1,88 @@
+import { useFrame } from '@react-three/fiber'
+import { useEffect, useRef } from 'react'
+import { AdditiveBlending, Color, DoubleSide, type PlaneGeometry, type ShaderMaterial } from 'three'
+
+interface Props {
+  color: string
+  intensity: number
+}
+
+const glowVertexShader = /* glsl */ `
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`
+
+const glowFragmentShader = /* glsl */ `
+uniform float uTime;
+uniform vec3 uColor;
+uniform float uIntensity;
+varying vec2 vUv;
+
+void main() {
+  vec2 centered = (vUv - 0.5) * 2.0;
+  float dist = length(centered);
+
+  // 円形のソフトグロー
+  float glow = exp(-dist * dist * 5.0);
+
+  // ふわふわ脈動
+  float pulse = sin(uTime * 1.5) * 0.08 + 0.92;
+  float pulse2 = sin(uTime * 2.7 + 1.0) * 0.05 + 0.95;
+
+  float brightness = glow * pulse * pulse2 * uIntensity * 5.0;
+  vec3 finalColor = uColor * brightness;
+
+  float alpha = glow * pulse * 1.2;
+  if (alpha < 0.01) discard;
+
+  gl_FragColor = vec4(finalColor, alpha);
+}
+`
+
+const INITIAL_UNIFORMS = {
+  uTime: { value: 0 },
+  uColor: { value: [0.6, 0.33, 1.0] as [number, number, number] },
+  uIntensity: { value: 1.5 },
+}
+
+export const PortalGlow = ({ color, intensity }: Props) => {
+  const materialRef = useRef<ShaderMaterial>(null)
+  const geometryRef = useRef<PlaneGeometry>(null)
+
+  useFrame((_, delta) => {
+    if (!materialRef.current) return
+    materialRef.current.uniforms.uTime.value += delta
+
+    const c = new Color(color)
+    materialRef.current.uniforms.uColor.value = [c.r, c.g, c.b]
+    materialRef.current.uniforms.uIntensity.value = intensity
+  })
+
+  useEffect(() => {
+    const material = materialRef.current
+    const geometry = geometryRef.current
+    return () => {
+      material?.dispose()
+      geometry?.dispose()
+    }
+  }, [])
+
+  return (
+    <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.16, 0]}>
+      <planeGeometry ref={geometryRef} args={[2, 2]} />
+      <shaderMaterial
+        ref={materialRef}
+        vertexShader={glowVertexShader}
+        fragmentShader={glowFragmentShader}
+        uniforms={INITIAL_UNIFORMS}
+        transparent
+        blending={AdditiveBlending}
+        depthWrite={false}
+        side={DoubleSide}
+      />
+    </mesh>
+  )
+}

--- a/src/components/Portal/components/PortalParticles/index.tsx
+++ b/src/components/Portal/components/PortalParticles/index.tsx
@@ -1,0 +1,164 @@
+import { useFrame } from '@react-three/fiber'
+import { useEffect, useMemo, useRef } from 'react'
+import { AdditiveBlending, type BufferAttribute, type BufferGeometry, Color, type Points, type ShaderMaterial } from 'three'
+
+interface Props {
+  particleCount: number
+  color: string
+  portalRadius: number
+  rotationSpeed: number
+}
+
+const particleVertexShader = /* glsl */ `
+attribute float aOpacity;
+varying float vOpacity;
+
+void main() {
+  vOpacity = aOpacity;
+  vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+  gl_PointSize = 30.0 / -mvPosition.z;
+  gl_Position = projectionMatrix * mvPosition;
+}
+`
+
+const particleFragmentShader = /* glsl */ `
+uniform vec3 uColor;
+varying float vOpacity;
+
+void main() {
+  // 円形のポイント
+  float dist = length(gl_PointCoord - vec2(0.5));
+  if (dist > 0.5) discard;
+  float soft = 1.0 - smoothstep(0.3, 0.5, dist);
+  gl_FragColor = vec4(uColor, soft * vOpacity);
+}
+`
+
+const INITIAL_UNIFORMS = {
+  uColor: { value: [0.73, 0.53, 1.0] as [number, number, number] },
+}
+
+const initParticles = (count: number, radius: number) => {
+  const positions = new Float32Array(count * 3)
+  const opacities = new Float32Array(count)
+  const speeds = new Float32Array(count)
+
+  for (let i = 0; i < count; i++) {
+    const angle = Math.random() * Math.PI * 2
+    const dist = radius * (0.3 + Math.random() * 0.7)
+    const height = Math.random() * 0.8 + 0.2
+
+    positions[i * 3] = Math.cos(angle) * dist
+    positions[i * 3 + 1] = height
+    positions[i * 3 + 2] = Math.sin(angle) * dist
+
+    opacities[i] = 0.0
+    speeds[i] = 0.3 + Math.random() * 0.7
+  }
+
+  return { positions, opacities, speeds }
+}
+
+const MAX_HEIGHT = 1.0
+const FADE_START = 0.7
+
+export const PortalParticles = ({ particleCount, color, portalRadius, rotationSpeed }: Props) => {
+  const pointsRef = useRef<Points>(null)
+  const geometryRef = useRef<BufferGeometry>(null)
+  const materialRef = useRef<ShaderMaterial>(null)
+  const timeRef = useRef(0)
+
+  const { positions, opacities, speeds } = useMemo(
+    () => initParticles(particleCount, portalRadius),
+    [particleCount, portalRadius],
+  )
+
+  useFrame((_, delta) => {
+    if (!geometryRef.current || !materialRef.current) return
+    timeRef.current += delta
+
+    const c = new Color(color)
+    materialRef.current.uniforms.uColor.value = [c.r, c.g, c.b]
+
+    const posAttr = geometryRef.current.getAttribute('position') as BufferAttribute
+    const posArray = posAttr.array as Float32Array
+    const opacityAttr = geometryRef.current.getAttribute('aOpacity') as BufferAttribute
+    const opacityArray = opacityAttr.array as Float32Array
+
+    for (let i = 0; i < particleCount; i++) {
+      const x = posArray[i * 3]
+      let y = posArray[i * 3 + 1]
+      const z = posArray[i * 3 + 2]
+
+      const angle = Math.atan2(z, x)
+      const dist = Math.sqrt(x * x + z * z)
+
+      const angularSpeed = speeds[i] * rotationSpeed * (2.0 + 1.5 / (dist + 0.1))
+      const newAngle = angle + angularSpeed * delta
+
+      const shrinkRate = 0.25 * speeds[i]
+      const fallRate = 0.35 * speeds[i]
+      let newDist = dist - shrinkRate * delta
+      y -= fallRate * delta
+
+      // 高さに応じたフェードイン（上=透明、下=不透明）
+      const normalizedHeight = Math.min(Math.max((MAX_HEIGHT - y) / (MAX_HEIGHT - 0.15), 0), 1)
+      opacityArray[i] = normalizedHeight < FADE_START
+        ? normalizedHeight / FADE_START * 0.8
+        : 0.8
+
+      if (newDist < 0.05 || y < 0.15) {
+        const resetAngle = Math.random() * Math.PI * 2
+        newDist = portalRadius * (0.5 + Math.random() * 0.5)
+        y = 0.5 + Math.random() * 0.5
+        opacityArray[i] = 0.0
+
+        posArray[i * 3] = Math.cos(resetAngle) * newDist
+        posArray[i * 3 + 1] = y
+        posArray[i * 3 + 2] = Math.sin(resetAngle) * newDist
+      } else {
+        posArray[i * 3] = Math.cos(newAngle) * newDist
+        posArray[i * 3 + 1] = y
+        posArray[i * 3 + 2] = Math.sin(newAngle) * newDist
+      }
+    }
+
+    posAttr.needsUpdate = true
+    opacityAttr.needsUpdate = true
+  })
+
+  useEffect(() => {
+    const geometry = geometryRef.current
+    const material = materialRef.current
+    return () => {
+      geometry?.dispose()
+      material?.dispose()
+    }
+  }, [])
+
+  return (
+    <points ref={pointsRef}>
+      <bufferGeometry ref={geometryRef}>
+        <bufferAttribute
+          attach="attributes-position"
+          args={[positions, 3]}
+          count={particleCount}
+        />
+        <bufferAttribute
+          attach="attributes-aOpacity"
+          args={[opacities, 1]}
+          count={particleCount}
+        />
+      </bufferGeometry>
+      <shaderMaterial
+        ref={materialRef}
+        vertexShader={particleVertexShader}
+        fragmentShader={particleFragmentShader}
+        uniforms={INITIAL_UNIFORMS}
+        transparent
+        blending={AdditiveBlending}
+        depthWrite={false}
+      />
+    </points>
+  )
+}

--- a/src/components/Portal/components/PortalPedestal/index.tsx
+++ b/src/components/Portal/components/PortalPedestal/index.tsx
@@ -1,0 +1,87 @@
+import { CuboidCollider, RigidBody } from '@react-three/rapier'
+import { useEffect, useRef } from 'react'
+import { type CylinderGeometry, DoubleSide, type ShaderMaterial } from 'three'
+import { simplexNoise3D } from '../../shaders/noise'
+
+const PEDESTAL_HEIGHT = 0.15
+const BOTTOM_RADIUS = 1.4
+const TOP_RADIUS = 1.25
+
+const vertexShader = /* glsl */ `
+varying vec3 vPosition;
+varying vec3 vNormal;
+
+void main() {
+  vPosition = position;
+  vNormal = normalize(normalMatrix * normal);
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`
+
+const fragmentShader = /* glsl */ `
+${simplexNoise3D}
+
+varying vec3 vPosition;
+varying vec3 vNormal;
+
+void main() {
+  // 3Dノイズで石のまだら模様
+  float n1 = snoise(vPosition * 1.5) * 0.04;
+  float n2 = snoise(vPosition * 4.0) * 0.02;
+  float noise = n1 + n2;
+
+  // ベースの灰色にノイズを加える
+  vec3 baseColor = vec3(0.2, 0.2, 0.2);
+  vec3 stoneColor = baseColor + vec3(noise);
+
+  // 簡易ライティング（上からの光）
+  float light = dot(vNormal, vec3(0.0, 1.0, 0.0)) * 0.3 + 0.7;
+
+  gl_FragColor = vec4(stoneColor * light, 1.0);
+}
+`
+
+const INITIAL_UNIFORMS = {}
+
+const SENSOR_HALF_WIDTH = TOP_RADIUS * 0.6
+const SENSOR_HALF_HEIGHT = 0.8
+
+interface Props {
+  onEnter?: () => void
+}
+
+export const PortalPedestal = ({ onEnter }: Props) => {
+  const materialRef = useRef<ShaderMaterial>(null)
+  const geometryRef = useRef<CylinderGeometry>(null)
+
+  useEffect(() => {
+    const material = materialRef.current
+    const geometry = geometryRef.current
+    return () => {
+      material?.dispose()
+      geometry?.dispose()
+    }
+  }, [])
+
+  return (
+    <RigidBody type="fixed" colliders="trimesh">
+      <mesh position={[0, PEDESTAL_HEIGHT / 2, 0]} rotation={[0, Math.PI / 4, 0]}>
+        <cylinderGeometry ref={geometryRef} args={[TOP_RADIUS, BOTTOM_RADIUS, PEDESTAL_HEIGHT, 4]} />
+        <shaderMaterial
+          ref={materialRef}
+          vertexShader={vertexShader}
+          fragmentShader={fragmentShader}
+          uniforms={INITIAL_UNIFORMS}
+          side={DoubleSide}
+        />
+      </mesh>
+      {/* 台座上のセンサー（プレイヤー進入検知） */}
+      <CuboidCollider
+        args={[SENSOR_HALF_WIDTH, SENSOR_HALF_HEIGHT, SENSOR_HALF_WIDTH]}
+        position={[0, PEDESTAL_HEIGHT + SENSOR_HALF_HEIGHT, 0]}
+        sensor
+        onIntersectionEnter={onEnter}
+      />
+    </RigidBody>
+  )
+}

--- a/src/components/Portal/components/PortalThumbnail/index.tsx
+++ b/src/components/Portal/components/PortalThumbnail/index.tsx
@@ -1,0 +1,144 @@
+import { useFrame } from '@react-three/fiber'
+import { useEffect, useRef, useState } from 'react'
+import { type Group, type PlaneGeometry, type ShaderMaterial, Texture, TextureLoader } from 'three'
+import { simplexNoise3D } from '../../shaders/noise'
+
+interface Props {
+  thumbnailUrl?: string
+  portalRadius: number
+}
+
+const vertexShader = /* glsl */ `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`
+
+const fragmentShader = /* glsl */ `
+  ${simplexNoise3D}
+
+  uniform sampler2D uTexture;
+  uniform vec3 uGlowColor;
+  uniform float uTime;
+  varying vec2 vUv;
+  void main() {
+    vec2 center = vUv - 0.5;
+    float dist = length(center);
+    float angle = atan(center.y, center.x);
+
+    // ノイズで縁をグネグネさせる（0.42基準で余白を確保）
+    float noise = snoise(vec3(cos(angle) * 1.0, sin(angle) * 1.0, uTime * 0.5)) * 0.04;
+    float edge = 0.42 + noise;
+
+    // 外側グロー領域（縁の外にはみ出す光）
+    float glowWidth = 0.06;
+    if (dist > edge + glowWidth) discard;
+
+    if (dist > edge) {
+      // 縁の外側: 紫グローのみ
+      float outerGlow = 1.0 - smoothstep(edge, edge + glowWidth, dist);
+      gl_FragColor = vec4(uGlowColor, outerGlow * 0.6);
+      return;
+    }
+
+    // UVを円の範囲に合わせてスケーリング
+    float scale = 0.42 / 0.5;
+    vec2 scaledUv = (vUv - 0.5) / scale + 0.5;
+    vec4 texColor = texture2D(uTexture, scaledUv);
+
+    // 縁に近いほどグローを強くする
+    float edgeStart = edge - 0.12;
+    float glowStrength = smoothstep(edgeStart, edge, dist);
+    vec3 color = mix(texColor.rgb, uGlowColor, glowStrength * 0.7);
+
+    float alpha = texColor.a + glowStrength * 0.5;
+
+    gl_FragColor = vec4(color + uGlowColor * glowStrength * 0.3, alpha);
+  }
+`
+
+const INITIAL_UNIFORMS = {
+  uTexture: { value: null as Texture | null },
+  uGlowColor: { value: [0.6, 0.33, 1.0] as [number, number, number] },
+  uTime: { value: 0 },
+}
+
+export const PortalThumbnail = ({ thumbnailUrl, portalRadius }: Props) => {
+  const [texture, setTexture] = useState<Texture | null>(null)
+  const meshRef = useRef<Group>(null)
+  const geometryRef = useRef<PlaneGeometry>(null)
+  const materialRef = useRef<ShaderMaterial>(null)
+
+  useEffect(() => {
+    if (!thumbnailUrl) return
+
+    const loader = new TextureLoader()
+    loader.setCrossOrigin('anonymous')
+
+    let cancelled = false
+    loader.load(
+      thumbnailUrl,
+      (loaded) => {
+        if (cancelled) return
+        setTexture(loaded)
+      },
+      undefined,
+      (err) => {
+        console.error('PortalThumbnail: texture load failed', err)
+      },
+    )
+
+    return () => {
+      cancelled = true
+      setTexture((prev) => {
+        prev?.dispose()
+        return null
+      })
+    }
+  }, [thumbnailUrl])
+
+  useEffect(() => {
+    if (!materialRef.current || !texture) return
+    materialRef.current.uniforms.uTexture.value = texture
+  }, [texture])
+
+  useEffect(() => {
+    const geometry = geometryRef.current
+    const material = materialRef.current
+    return () => {
+      geometry?.dispose()
+      material?.dispose()
+    }
+  }, [])
+
+  const baseY = portalRadius * 0.15 + 0.15 + portalRadius * 0.7
+
+  useFrame(({ clock }) => {
+    if (!meshRef.current) return
+    meshRef.current.position.y = baseY + Math.sin(clock.getElapsedTime()) * 0.05
+    if (materialRef.current) {
+      materialRef.current.uniforms.uTime.value = clock.getElapsedTime()
+    }
+  })
+
+  if (!texture) return null
+
+  const size = portalRadius * (2 / 3) * 2
+
+  return (
+    <group ref={meshRef} position={[0, baseY, 0]}>
+      <mesh>
+        <planeGeometry ref={geometryRef} args={[size, size]} />
+        <shaderMaterial
+          ref={materialRef}
+          vertexShader={vertexShader}
+          fragmentShader={fragmentShader}
+          uniforms={INITIAL_UNIFORMS}
+          transparent
+        />
+      </mesh>
+    </group>
+  )
+}

--- a/src/components/Portal/components/PortalVortex/index.tsx
+++ b/src/components/Portal/components/PortalVortex/index.tsx
@@ -1,0 +1,73 @@
+import { useFrame } from '@react-three/fiber'
+import { useEffect, useRef } from 'react'
+import { AdditiveBlending, Color, type ConeGeometry, DoubleSide, type Mesh, type ShaderMaterial } from 'three'
+import { portalFragmentShader } from '../../shaders/portalFragment'
+import { portalVertexShader } from '../../shaders/portalVertex'
+
+interface Props {
+  color: string
+  secondaryColor: string
+  intensity: number
+  rotationSpeed: number
+  portalRadius: number
+}
+
+const INITIAL_UNIFORMS = {
+  uTime: { value: 0 },
+  uColor: { value: [0.6, 0.33, 1.0] as [number, number, number] },
+  uSecondaryColor: { value: [0.73, 0.53, 1.0] as [number, number, number] },
+  uIntensity: { value: 1.5 },
+}
+
+const CONE_SEGMENTS = 24
+const CONE_HEIGHT_SEGMENTS = 12
+
+export const PortalVortex = ({ color, secondaryColor, intensity, rotationSpeed, portalRadius }: Props) => {
+  const meshRef = useRef<Mesh>(null)
+  const materialRef = useRef<ShaderMaterial>(null)
+  const geometryRef = useRef<ConeGeometry>(null)
+
+  useFrame((_, delta) => {
+    if (!materialRef.current || !meshRef.current) return
+
+    materialRef.current.uniforms.uTime.value += delta
+
+    const mainColor = new Color(color)
+    const subColor = new Color(secondaryColor)
+    materialRef.current.uniforms.uColor.value = [mainColor.r, mainColor.g, mainColor.b]
+    materialRef.current.uniforms.uSecondaryColor.value = [subColor.r, subColor.g, subColor.b]
+    materialRef.current.uniforms.uIntensity.value = intensity
+
+    meshRef.current.rotation.y += rotationSpeed * delta
+  })
+
+  useEffect(() => {
+    const material = materialRef.current
+    const geometry = geometryRef.current
+    return () => {
+      material?.dispose()
+      geometry?.dispose()
+    }
+  }, [])
+
+  const height = portalRadius * 0.15
+
+  return (
+    <mesh ref={meshRef} rotation={[Math.PI, 0, 0]} position={[0, height / 2 + 0.15, 0]}>
+      <coneGeometry
+        ref={geometryRef}
+        args={[portalRadius, height, CONE_SEGMENTS, CONE_HEIGHT_SEGMENTS, true]}
+      />
+      <shaderMaterial
+        ref={materialRef}
+        vertexShader={portalVertexShader}
+        fragmentShader={portalFragmentShader}
+        uniforms={INITIAL_UNIFORMS}
+        transparent
+        blending={AdditiveBlending}
+        depthWrite={false}
+        side={DoubleSide}
+      />
+    </mesh>
+  )
+}

--- a/src/components/Portal/constants.ts
+++ b/src/components/Portal/constants.ts
@@ -1,0 +1,11 @@
+import type { Vector3Tuple } from 'three'
+
+export const PORTAL_DEFAULTS = {
+  position: [0, 0, 0] as Vector3Tuple,
+  rotation: [0, 0, 0] as Vector3Tuple,
+  color: '#9955ff',
+  secondaryColor: '#bb88ff',
+  intensity: 1.5,
+  rotationSpeed: 0.5,
+  portalRadius: 0.9,
+} as const

--- a/src/components/Portal/hooks.ts
+++ b/src/components/Portal/hooks.ts
@@ -1,0 +1,21 @@
+import { PORTAL_DEFAULTS } from './constants'
+import type { Props } from './types'
+
+/**
+ * Propsにデフォルト値を適用して返す
+ */
+export const usePortalProps = (props: Props) => {
+  const {
+    position = PORTAL_DEFAULTS.position,
+    rotation = PORTAL_DEFAULTS.rotation,
+    thumbnailUrl,
+    onEnter,
+  } = props
+
+  return {
+    position,
+    rotation,
+    thumbnailUrl,
+    onEnter,
+  }
+}

--- a/src/components/Portal/index.tsx
+++ b/src/components/Portal/index.tsx
@@ -1,0 +1,48 @@
+import { PortalGlow } from './components/PortalGlow'
+import { PortalParticles } from './components/PortalParticles'
+import { PortalPedestal } from './components/PortalPedestal'
+import { PortalThumbnail } from './components/PortalThumbnail'
+import { PortalVortex } from './components/PortalVortex'
+import { PORTAL_DEFAULTS } from './constants'
+import { usePortalProps } from './hooks'
+import type { Props } from './types'
+
+export type { Props as PortalProps } from './types'
+
+const PARTICLE_COUNT = 30
+
+export const Portal = (props: Props) => {
+  const {
+    position,
+    rotation,
+    thumbnailUrl,
+    onEnter,
+  } = usePortalProps(props)
+
+  return (
+    <group position={position} rotation={rotation}>
+      <PortalVortex
+        color={PORTAL_DEFAULTS.color}
+        secondaryColor={PORTAL_DEFAULTS.secondaryColor}
+        intensity={PORTAL_DEFAULTS.intensity}
+        rotationSpeed={PORTAL_DEFAULTS.rotationSpeed}
+        portalRadius={PORTAL_DEFAULTS.portalRadius}
+      />
+      <PortalThumbnail
+        thumbnailUrl={thumbnailUrl}
+        portalRadius={PORTAL_DEFAULTS.portalRadius}
+      />
+      <PortalGlow
+        color={PORTAL_DEFAULTS.secondaryColor}
+        intensity={PORTAL_DEFAULTS.intensity}
+      />
+      <PortalParticles
+        particleCount={PARTICLE_COUNT}
+        color={PORTAL_DEFAULTS.secondaryColor}
+        portalRadius={PORTAL_DEFAULTS.portalRadius}
+        rotationSpeed={PORTAL_DEFAULTS.rotationSpeed}
+      />
+      <PortalPedestal onEnter={onEnter} />
+    </group>
+  )
+}

--- a/src/components/Portal/shaders/noise.ts
+++ b/src/components/Portal/shaders/noise.ts
@@ -1,0 +1,82 @@
+// Simplex 3D Noise - GLSL
+// Author: Ian McEwan, Ashima Arts
+// License: MIT License
+// https://github.com/ashima/webgl-noise
+
+export const simplexNoise3D = /* glsl */ `
+vec3 mod289(vec3 x) {
+  return x - floor(x * (1.0 / 289.0)) * 289.0;
+}
+
+vec4 mod289(vec4 x) {
+  return x - floor(x * (1.0 / 289.0)) * 289.0;
+}
+
+vec4 permute(vec4 x) {
+  return mod289(((x * 34.0) + 1.0) * x);
+}
+
+vec4 taylorInvSqrt(vec4 r) {
+  return 1.79284291400159 - 0.85373472095314 * r;
+}
+
+float snoise(vec3 v) {
+  const vec2 C = vec2(1.0 / 6.0, 1.0 / 3.0);
+  const vec4 D = vec4(0.0, 0.5, 1.0, 2.0);
+
+  vec3 i = floor(v + dot(v, C.yyy));
+  vec3 x0 = v - i + dot(i, C.xxx);
+
+  vec3 g = step(x0.yzx, x0.xyz);
+  vec3 l = 1.0 - g;
+  vec3 i1 = min(g.xyz, l.zxy);
+  vec3 i2 = max(g.xyz, l.zxy);
+
+  vec3 x1 = x0 - i1 + C.xxx;
+  vec3 x2 = x0 - i2 + C.yyy;
+  vec3 x3 = x0 - D.yyy;
+
+  i = mod289(i);
+  vec4 p = permute(permute(permute(
+    i.z + vec4(0.0, i1.z, i2.z, 1.0))
+    + i.y + vec4(0.0, i1.y, i2.y, 1.0))
+    + i.x + vec4(0.0, i1.x, i2.x, 1.0));
+
+  float n_ = 0.142857142857;
+  vec3 ns = n_ * D.wyz - D.xzx;
+
+  vec4 j = p - 49.0 * floor(p * ns.z * ns.z);
+
+  vec4 x_ = floor(j * ns.z);
+  vec4 y_ = floor(j - 7.0 * x_);
+
+  vec4 x = x_ * ns.x + ns.yyyy;
+  vec4 y = y_ * ns.x + ns.yyyy;
+  vec4 h = 1.0 - abs(x) - abs(y);
+
+  vec4 b0 = vec4(x.xy, y.xy);
+  vec4 b1 = vec4(x.zw, y.zw);
+
+  vec4 s0 = floor(b0) * 2.0 + 1.0;
+  vec4 s1 = floor(b1) * 2.0 + 1.0;
+  vec4 sh = -step(h, vec4(0.0));
+
+  vec4 a0 = b0.xzyw + s0.xzyw * sh.xxyy;
+  vec4 a1 = b1.xzyw + s1.xzyw * sh.zzww;
+
+  vec3 p0 = vec3(a0.xy, h.x);
+  vec3 p1 = vec3(a0.zw, h.y);
+  vec3 p2 = vec3(a1.xy, h.z);
+  vec3 p3 = vec3(a1.zw, h.w);
+
+  vec4 norm = taylorInvSqrt(vec4(dot(p0, p0), dot(p1, p1), dot(p2, p2), dot(p3, p3)));
+  p0 *= norm.x;
+  p1 *= norm.y;
+  p2 *= norm.z;
+  p3 *= norm.w;
+
+  vec4 m = max(0.6 - vec4(dot(x0, x0), dot(x1, x1), dot(x2, x2), dot(x3, x3)), 0.0);
+  m = m * m;
+  return 42.0 * dot(m * m, vec4(dot(p0, x0), dot(p1, x1), dot(p2, x2), dot(p3, x3)));
+}
+`

--- a/src/components/Portal/shaders/portalFragment.ts
+++ b/src/components/Portal/shaders/portalFragment.ts
@@ -1,0 +1,45 @@
+import { simplexNoise3D } from './noise'
+
+export const portalFragmentShader = /* glsl */ `
+${simplexNoise3D}
+
+uniform float uTime;
+uniform vec3 uColor;
+uniform vec3 uSecondaryColor;
+uniform float uIntensity;
+
+varying vec2 vUv;
+varying vec3 vPosition;
+
+void main() {
+  // 3D位置から角度を計算（UV継ぎ目なし）
+  float angle = atan(vPosition.z, vPosition.x);
+  float height = vUv.y; // 0=頂点, 1=底面
+
+  // 高さに応じてねじり（頂点側ほど強くねじれる）
+  float twistedAngle = angle - (1.0 - height) * 3.0;
+
+  // ストライプパターン
+  float arms = 8.0;
+  float rawPattern = sin(twistedAngle * arms) * 0.5 + 0.5;
+  float radialPattern = smoothstep(0.2, 0.6, rawPattern);
+
+  // 緩やかな脈動
+  float pulse = sin(uTime * 2.0) * 0.08 + 0.92;
+
+  // 底面側（上）を明るく、頂点側（下）を暗く
+  float heightBrightness = smoothstep(0.0, 0.5, height);
+
+  // 距離ベースの色混合（頂点=メインカラー、底面=サブカラー）
+  vec3 baseColor = mix(uColor, uSecondaryColor, height);
+
+  // 最終色合成
+  float brightness = (radialPattern * 0.7 + heightBrightness * 0.3) * pulse * uIntensity;
+  vec3 finalColor = baseColor * brightness;
+
+  // 頂点付近をフェードアウト
+  float alpha = smoothstep(0.0, 0.5, height) * clamp(brightness, 0.0, 1.0);
+
+  gl_FragColor = vec4(finalColor, alpha);
+}
+`

--- a/src/components/Portal/shaders/portalVertex.ts
+++ b/src/components/Portal/shaders/portalVertex.ts
@@ -1,0 +1,10 @@
+export const portalVertexShader = /* glsl */ `
+varying vec2 vUv;
+varying vec3 vPosition;
+
+void main() {
+  vUv = uv;
+  vPosition = position;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`

--- a/src/components/Portal/types.ts
+++ b/src/components/Portal/types.ts
@@ -1,0 +1,15 @@
+import type { Vector3Tuple } from 'three'
+
+export interface Props {
+  position?: Vector3Tuple
+  rotation?: Vector3Tuple
+  thumbnailUrl?: string
+  onEnter?: () => void
+}
+
+export interface PortalUniforms {
+  uTime: { value: number }
+  uColor: { value: [number, number, number] }
+  uSecondaryColor: { value: [number, number, number] }
+  uIntensity: { value: number }
+}

--- a/src/components/Portal/utils.ts
+++ b/src/components/Portal/utils.ts
@@ -1,0 +1,36 @@
+/**
+ * パーティクルの初期位置を生成する
+ * 渦巻き軌道上にランダムに配置
+ */
+export const generateParticlePositions = (count: number, radius: number, aspectRatio: number): Float32Array => {
+  const positions = new Float32Array(count * 3)
+
+  for (let i = 0; i < count; i++) {
+    const angle = Math.random() * Math.PI * 2
+    const dist = Math.random() * radius
+    const x = Math.cos(angle) * dist
+    const y = Math.sin(angle) * dist * aspectRatio
+    const z = (Math.random() - 0.5) * 0.2
+
+    positions[i * 3] = x
+    positions[i * 3 + 1] = y
+    positions[i * 3 + 2] = z
+  }
+
+  return positions
+}
+
+/**
+ * パーティクルの初期速度パラメータを生成する
+ * 各パーティクルの角速度・半径方向速度の基準値
+ */
+export const generateParticleVelocities = (count: number): Float32Array => {
+  const velocities = new Float32Array(count * 2) // [angularSpeed, radialPhase] per particle
+
+  for (let i = 0; i < count; i++) {
+    velocities[i * 2] = 0.5 + Math.random() * 1.5 // 角速度: 0.5〜2.0
+    velocities[i * 2 + 1] = Math.random() * Math.PI * 2 // 初期位相
+  }
+
+  return velocities
+}

--- a/src/contexts/ConfirmContext.tsx
+++ b/src/contexts/ConfirmContext.tsx
@@ -1,0 +1,50 @@
+import { createContext, type ReactNode, useContext } from 'react'
+
+export interface ConfirmOptions {
+  title?: string
+  message: string
+  confirmLabel?: string
+  cancelLabel?: string
+}
+
+export interface ConfirmContextValue {
+  requestConfirm: (options: ConfirmOptions) => Promise<boolean>
+}
+
+/**
+ * 開発環境用のデフォルト実装（window.confirm）
+ * プラットフォーム側が実装を注入しない場合に使用される
+ */
+export const createDefaultConfirmImplementation = (): ConfirmContextValue => ({
+  requestConfirm: (options) => Promise.resolve(window.confirm(options.message)),
+})
+
+/**
+ * 確認モーダル機能を提供する Context
+ * xrift-frontend 側で実装を注入し、ワールド側で利用できる
+ */
+export const ConfirmContext = createContext<ConfirmContextValue | null>(null)
+
+interface Props {
+  value: ConfirmContextValue
+  children: ReactNode
+}
+
+/**
+ * 確認モーダル機能を提供する ContextProvider
+ */
+export const ConfirmProvider = ({ value, children }: Props) => {
+  return <ConfirmContext.Provider value={value}>{children}</ConfirmContext.Provider>
+}
+
+/**
+ * 確認モーダルの Context を取得する hook
+ * @throws {Error} ConfirmProvider の外で呼び出された場合
+ */
+export const useConfirmContext = (): ConfirmContextValue => {
+  const context = useContext(ConfirmContext)
+  if (!context) {
+    throw new Error('useConfirmContext must be used within ConfirmProvider')
+  }
+  return context
+}

--- a/src/contexts/XRiftContext.tsx
+++ b/src/contexts/XRiftContext.tsx
@@ -4,6 +4,11 @@ import { InstanceStateProvider, type InstanceStateContextValue } from './Instanc
 import { ScreenShareProvider, type ScreenShareContextValue } from './ScreenShareContext'
 import { SpawnPointProvider, type SpawnPointContextValue } from './SpawnPointContext'
 import {
+  ConfirmProvider,
+  createDefaultConfirmImplementation,
+  type ConfirmContextValue,
+} from './ConfirmContext'
+import {
   TeleportProvider,
   createDefaultTeleportImplementation,
   type TeleportContextValue,
@@ -78,6 +83,11 @@ interface Props {
    */
   spawnPointImplementation?: SpawnPointContextValue
   /**
+   * 確認モーダルの実装（オプション）
+   * 指定しない場合はデフォルト実装（window.confirm）が使用される
+   */
+  confirmImplementation?: ConfirmContextValue
+  /**
    * テレポート機能の実装（オプション）
    * 指定しない場合はデフォルト実装（console.log）が使用される
    */
@@ -107,6 +117,7 @@ interface Props {
  */
 export const XRiftProvider = ({
   baseUrl,
+  confirmImplementation,
   instanceStateImplementation,
   screenShareImplementation,
   spawnPointImplementation,
@@ -129,6 +140,12 @@ export const XRiftProvider = ({
   const textInputImpl = useMemo(
     () => textInputImplementation ?? createDefaultTextInputImplementation(),
     [textInputImplementation],
+  )
+
+  // 確認モーダルの実装（指定がない場合はデフォルト実装を使用）
+  const confirmImpl = useMemo(
+    () => confirmImplementation ?? createDefaultConfirmImplementation(),
+    [confirmImplementation],
   )
 
   // テレポートの実装（指定がない場合はデフォルト実装を使用）
@@ -169,7 +186,9 @@ export const XRiftProvider = ({
               <UsersProvider implementation={usersImplementation}>
                 <WorldEventProvider value={worldEventImpl}>
                   <TeleportProvider value={teleportImpl}>
-                    {children}
+                    <ConfirmProvider value={confirmImpl}>
+                      {children}
+                    </ConfirmProvider>
                   </TeleportProvider>
                 </WorldEventProvider>
               </UsersProvider>

--- a/src/hooks/useConfirm.ts
+++ b/src/hooks/useConfirm.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react'
+import { type ConfirmOptions, useConfirmContext } from '../contexts/ConfirmContext'
+
+/**
+ * 確認モーダルを使用するhook
+ * ワールド作成者がユーザーに確認を求めるために使用
+ *
+ * @example
+ * const { requestConfirm } = useConfirm()
+ *
+ * const handleEnter = async () => {
+ *   const ok = await requestConfirm({ message: 'ワールドを移動しますか？' })
+ *   if (ok) navigate('/worlds/abc')
+ * }
+ *
+ * @returns {{ requestConfirm: (options: ConfirmOptions) => Promise<boolean> }}
+ */
+export const useConfirm = (): { requestConfirm: (options: ConfirmOptions) => Promise<boolean> } => {
+  const { requestConfirm } = useConfirmContext()
+
+  const stableRequestConfirm = useCallback(
+    (options: ConfirmOptions) => {
+      return requestConfirm(options)
+    },
+    [requestConfirm],
+  )
+
+  return { requestConfirm: stableRequestConfirm }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,15 @@ export {
 } from './contexts/TextInputContext'
 
 export {
+  ConfirmContext,
+  ConfirmProvider,
+  useConfirmContext,
+  createDefaultConfirmImplementation,
+  type ConfirmContextValue,
+  type ConfirmOptions,
+} from './contexts/ConfirmContext'
+
+export {
   TeleportContext,
   TeleportProvider,
   useTeleportContext,
@@ -117,11 +126,14 @@ export {
   type EntryLogBoardProps,
 } from './components/EntryLogBoard'
 
+export { Portal, type PortalProps } from './components/Portal'
+
 export { type PhysicsConfig } from './components/DevEnvironment/types'
 
 // Hooks
 export { useInstanceState } from './hooks/useInstanceState'
 export { useSpawnPoint } from './hooks/useSpawnPoint'
+export { useConfirm } from './hooks/useConfirm'
 export { useTeleport } from './hooks/useTeleport'
 export { useWebAudioVolume } from './hooks/useWebAudioVolume'
 export { useWorldEvent } from './hooks/useWorldEvent'


### PR DESCRIPTION
## Summary
- ワールド間移動用の Portal コンポーネントを追加（渦巻きエフェクト、サムネイル表示、パーティクル、台座を含む）
- 確認モーダル機能を提供する ConfirmContext / useConfirm hook を追加
- XRiftProvider に ConfirmProvider を統合（プラットフォーム側から実装注入可能）

## 追加ファイル

### Portal コンポーネント (`src/components/Portal/`)
- `index.tsx` - メインコンポーネント
- `types.ts` / `constants.ts` / `hooks.ts` / `utils.ts`
- `components/` - PortalVortex, PortalThumbnail, PortalGlow, PortalParticles, PortalPedestal
- `shaders/` - ポータル用シェーダー（noise, vertex, fragment）
- `__tests__/utils.test.ts` - ユーティリティ関数のテスト

### ConfirmContext (`src/contexts/ConfirmContext.tsx`)
- `requestConfirm(options)` で確認モーダルを表示し、`Promise<boolean>` で結果を取得
- デフォルト実装は `window.confirm`（開発環境用）

### useConfirm hook (`src/hooks/useConfirm.ts`)
- ワールド作成者向けの簡易API

## Test plan
- [ ] Portal コンポーネントが正しくレンダリングされる
- [ ] サムネイルURLが表示される
- [ ] 台座をクリックで onEnter が発火する
- [ ] useConfirm で確認モーダルが機能する
- [ ] `npm run test` でユーティリティ関数のテストが通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)