### PR TITLE
refactor: useSyncExternalStoreで外部状態購読を統一

### DIFF
--- a/src/components/DevEnvironment/index.tsx
+++ b/src/components/DevEnvironment/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState, useSyncExternalStore } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { PointerLockControls } from '@react-three/drei'
 import { Physics } from '@react-three/rapier'
@@ -25,6 +25,17 @@ const containerStyle: React.CSSProperties = {
   position: 'relative',
 }
 
+function subscribePointerLock(listener: () => void): () => void {
+  document.addEventListener('pointerlockchange', listener)
+  return () => {
+    document.removeEventListener('pointerlockchange', listener)
+  }
+}
+
+function getPointerLockSnapshot(): boolean {
+  return document.pointerLockElement !== null
+}
+
 export function DevEnvironment({
   children,
   camera,
@@ -35,7 +46,11 @@ export function DevEnvironment({
   physicsConfig,
 }: Props) {
   const [isHit, setIsHit] = useState(false)
-  const [isPointerLocked, setIsPointerLocked] = useState(false)
+  const isPointerLocked = useSyncExternalStore(
+    subscribePointerLock,
+    getPointerLockSnapshot,
+    () => false,
+  )
   const handleHitChange = useCallback((hit: boolean) => setIsHit(hit), [])
 
   const gravity = physicsConfig?.gravity ?? DEFAULT_GRAVITY
@@ -44,16 +59,6 @@ export function DevEnvironment({
 
   const cameraPosition = camera?.position ?? spawnPosition
   const cameraFov = camera?.fov ?? 50
-
-  useEffect(() => {
-    const handleChange = () => {
-      setIsPointerLocked(document.pointerLockElement !== null)
-    }
-    document.addEventListener('pointerlockchange', handleChange)
-    return () => {
-      document.removeEventListener('pointerlockchange', handleChange)
-    }
-  }, [])
 
   return (
     <div style={containerStyle}>


### PR DESCRIPTION
## Summary
- `useDebugMode`: `useState` + 2つの `useEffect` + `CustomEvent` → モジュールレベル変数 + `listeners` Set + `useSyncExternalStore` に置き換え
- `usePointerLock`: `isPointerLocked` の `useState` → `useSyncExternalStore` で `document.pointerLockElement` を購読。`handleClick` の依存配列から `isPointerLocked` を除去

## Test plan
- [ ] インスタンス内でデバッグモード ON/OFF が複数コンポーネント間で同期されること
- [ ] Canvas クリックでポインターロック取得、ESC で解除が正常に動作すること
- [ ] `npm run lint` でエラーなし ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)