### PR TITLE
feat: PlacementStateContext を追加して配置状態をアイテムに渡す

### DIFF
--- a/src/contexts/PlacementStateContext.tsx
+++ b/src/contexts/PlacementStateContext.tsx
@@ -1,0 +1,37 @@
+import { createContext, type ReactNode, useContext, useMemo } from 'react'
+
+export type PlacementMode = 'preview' | 'placed'
+
+export type PlacementStateContextValue = {
+  mode: PlacementMode
+}
+
+const FALLBACK_VALUE: PlacementStateContextValue = { mode: 'placed' }
+
+const PlacementStateContext = createContext<PlacementStateContextValue | null>(null)
+
+export function PlacementStateProvider({
+  mode,
+  children,
+}: {
+  mode: PlacementMode
+  children: ReactNode
+}) {
+  const value = useMemo(() => ({ mode }), [mode])
+  return (
+    <PlacementStateContext.Provider value={value}>
+      {children}
+    </PlacementStateContext.Provider>
+  )
+}
+
+/**
+ * アイテムの配置状態を取得するhook
+ * Provider 外では 'placed' をフォールバック
+ * 理由: Provider なし ＝ ワールド内の通常オブジェクト ＝ 設置済みとみなすのが自然
+ */
+export function usePlacementState(): PlacementStateContextValue {
+  const ctx = useContext(PlacementStateContext)
+  if (!ctx) return FALLBACK_VALUE
+  return ctx
+}

--- a/src/contexts/XRiftContext.tsx
+++ b/src/contexts/XRiftContext.tsx
@@ -34,6 +34,7 @@ import {
   createDefaultInstanceEventImplementation,
   type InstanceEventContextValue,
 } from './InstanceEventContext'
+import { PlacementStateProvider, type PlacementMode } from './PlacementStateContext'
 
 // デフォルトの画面共有実装（開発環境用）
 const createDefaultScreenShareImplementation = (): ScreenShareContextValue => ({
@@ -127,6 +128,12 @@ interface Props {
    * 指定しない場合はデフォルト実装（ローカル EventEmitter）が使用される
    */
   instanceEventImplementation?: InstanceEventContextValue
+  /**
+   * アイテムの配置状態（オプション）
+   * 'preview': プレビュー中、'placed': 設置済み
+   * 指定しない場合は Provider をスキップ（フォールバックで 'placed' が返る）
+   */
+  placementMode?: PlacementMode
   children: ReactNode
 }
 
@@ -147,6 +154,7 @@ export const XRiftProvider = ({
   usersImplementation,
   worldImplementation,
   instanceEventImplementation,
+  placementMode,
   children,
 }: Props) => {
   // インタラクト可能なオブジェクトの管理
@@ -223,7 +231,13 @@ export const XRiftProvider = ({
                     <ConfirmProvider value={confirmImpl}>
                       <WorldProvider value={worldImpl}>
                         <InstanceProvider value={instanceImpl}>
-                          {children}
+                          {placementMode ? (
+                            <PlacementStateProvider mode={placementMode}>
+                              {children}
+                            </PlacementStateProvider>
+                          ) : (
+                            children
+                          )}
                         </InstanceProvider>
                       </WorldProvider>
                     </ConfirmProvider>

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,13 @@ export {
   type InstanceEventContextValue,
 } from './contexts/InstanceEventContext'
 
+export {
+  PlacementStateProvider,
+  usePlacementState,
+  type PlacementMode,
+  type PlacementStateContextValue,
+} from './contexts/PlacementStateContext'
+
 // Components
 export {
   Interactable,


### PR DESCRIPTION
## Summary

- `PlacementStateContext` を新規作成し、`usePlacementState()` でアイテムが `preview` / `placed` を取得できるようにした
- `XRiftProvider` に `placementMode` プロップを追加し、指定時のみ `PlacementStateProvider` でラップ
- Provider 外では `{ mode: 'placed' }` にフォールバック（既存アイテムへの影響なし）

closes #128

## Test plan

- [x] 型チェック (`tsc --noEmit`) 通過
- [x] 既存テスト全件 (188 tests) 通過
- [ ] `usePlacementState()` を使わない既存アイテムが正常動作すること
- [ ] アイテム側で `usePlacementState()` を呼ぶと preview / placed を取得できること
- [ ] Provider 外で `usePlacementState()` を呼ぶと `{ mode: 'placed' }` が返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)