### PR TITLE
feat(Portal): disabled プロップを追加

### DIFF
--- a/src/components/Portal/hooks.ts
+++ b/src/components/Portal/hooks.ts
@@ -9,11 +9,13 @@ export const usePortalProps = (props: Props) => {
     instanceId,
     position = PORTAL_DEFAULTS.position,
     rotation = PORTAL_DEFAULTS.rotation,
+    disabled = false,
   } = props
 
   return {
     instanceId,
     position,
     rotation,
+    disabled,
   }
 }

--- a/src/components/Portal/index.tsx
+++ b/src/components/Portal/index.tsx
@@ -25,6 +25,7 @@ export const Portal = (props: Props) => {
     instanceId,
     position,
     rotation,
+    disabled,
   } = usePortalProps(props)
 
   const { info, navigateWithConfirm } = useInstance(instanceId)
@@ -52,7 +53,7 @@ export const Portal = (props: Props) => {
         portalRadius={PORTAL_DEFAULTS.portalRadius}
         rotationSpeed={PORTAL_DEFAULTS.rotationSpeed}
       />
-      <PortalPedestal onEnter={navigateWithConfirm} />
+      <PortalPedestal onEnter={disabled ? undefined : navigateWithConfirm} />
 
       {/* ワールド名・インスタンス名 */}
       {info && (

--- a/src/components/Portal/types.ts
+++ b/src/components/Portal/types.ts
@@ -4,6 +4,8 @@ export interface Props {
   instanceId: string
   position?: Vector3Tuple
   rotation?: Vector3Tuple
+  /** true の場合、ポータルによる遷移を無効化する */
+  disabled?: boolean
 }
 
 export interface PortalUniforms {


### PR DESCRIPTION
## Summary

- Portal コンポーネントに `disabled?: boolean` プロップを追加
- `disabled={true}` の場合、台座センサーの `onEnter` コールバックを無効化し遷移を防止
- ポータルの見た目（渦巻き、サムネイル、パーティクル等）はそのまま表示される

## 使い方

```tsx
<Portal instanceId="xxx" disabled />
```

## Test plan

- [x] 型チェック通過
- [x] 既存テスト全件 (188 tests) 通過
- [ ] `disabled` 未指定時は従来通り遷移できること
- [ ] `disabled={true}` 時に台座に乗っても遷移しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)