### PR TITLE
fix(ScreenShareDisplay): ガイドテキストが裏面から見えないように修正

### DIFF
--- a/src/components/ScreenShareDisplay/index.tsx
+++ b/src/components/ScreenShareDisplay/index.tsx
@@ -73,6 +73,7 @@ export const ScreenShareDisplay = memo(({
           anchorX="center"
           anchorY="middle"
           textAlign="center"
+          material-side={THREE.FrontSide}
         >
           {isRoomConnected ? 'クリックして画面共有' : '他のユーザーがいると\n画面共有できます'}
         </Text>


### PR DESCRIPTION
## Summary
- ScreenShareDisplay のガイドテキスト（「他のユーザーがいると画面共有できます」等）に `material-side={THREE.FrontSide}` を追加し、裏面から見えないように修正

## Test plan
- [ ] ScreenShareDisplay を裏側から見てもテキストが見えないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)