### PR TITLE
fix(VideoPlayer, LiveVideoPlayer): ガイドテキストのZ-fightingを根本解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.33.1",
+  "version": "0.33.2",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/LiveVideoPlayer/index.tsx
+++ b/src/components/LiveVideoPlayer/index.tsx
@@ -95,32 +95,37 @@ export const LiveVideoPlayer = memo(
     return (
       <group position={position} rotation={rotation}>
         {/* 画面本体 */}
-        {!videoState.url || isRetrying ? (
-          <>
-            <PlaceholderScreen
-              width={width}
-              screenHeight={screenHeight}
-              color="#000000"
-            />
-            {!videoState.url && !isRetrying && (
-              <Container
-                sizeX={width}
-                sizeY={screenHeight}
-                pixelSize={PIXEL_SIZE}
-                justifyContent="center"
-                alignItems="center"
-                flexDirection="column"
-                gap={4}
-              >
-                <Text fontSize={width / PIXEL_SIZE * 0.05} color={0x666666} textAlign="center">
-                  Enter Live Stream URL
-                </Text>
-                <Text fontSize={width / PIXEL_SIZE * 0.035} color={0x666666} textAlign="center">
-                  HLS .m3u8
-                </Text>
-              </Container>
-            )}
-          </>
+        {isRetrying ? (
+          <Container
+            sizeX={width}
+            sizeY={screenHeight}
+            pixelSize={PIXEL_SIZE}
+            backgroundColor={0x000000}
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Text fontSize={width / PIXEL_SIZE * 0.04} color={0xffcc00} textAlign="center">
+              Reconnecting...
+            </Text>
+          </Container>
+        ) : !videoState.url ? (
+          <Container
+            sizeX={width}
+            sizeY={screenHeight}
+            pixelSize={PIXEL_SIZE}
+            backgroundColor={0x000000}
+            justifyContent="center"
+            alignItems="center"
+            flexDirection="column"
+            gap={4}
+          >
+            <Text fontSize={width / PIXEL_SIZE * 0.05} color={0x666666} textAlign="center">
+              Enter Live Stream URL
+            </Text>
+            <Text fontSize={width / PIXEL_SIZE * 0.035} color={0x666666} textAlign="center">
+              HLS .m3u8
+            </Text>
+          </Container>
         ) : (
           <ErrorBoundary
             key={`error-boundary-${videoState.url}-${videoState.reloadKey}`}
@@ -154,21 +159,6 @@ export const LiveVideoPlayer = memo(
               />
             </Suspense>
           </ErrorBoundary>
-        )}
-
-        {/* リトライ中オーバーレイ */}
-        {isRetrying && (
-          <Container
-            sizeX={width}
-            sizeY={screenHeight}
-            pixelSize={PIXEL_SIZE}
-            justifyContent="center"
-            alignItems="center"
-          >
-            <Text fontSize={width / PIXEL_SIZE * 0.04} color={0xffcc00} textAlign="center">
-              Reconnecting...
-            </Text>
-          </Container>
         )}
 
         {/* コントロールパネル（スクリーン内オーバーレイ） */}

--- a/src/components/VideoPlayer/index.tsx
+++ b/src/components/VideoPlayer/index.tsx
@@ -183,23 +183,21 @@ export const VideoPlayer = memo(
     return (
       <group position={position} rotation={rotation}>
         {/* 画面本体 */}
-        {!currentUrl || hasError ? (
-          <>
-            <PlaceholderScreen width={width} screenHeight={screenHeight} color="#000000" />
-            {!currentUrl && (
-              <Container
-                sizeX={width}
-                sizeY={screenHeight}
-                pixelSize={PIXEL_SIZE}
-                justifyContent="center"
-                alignItems="center"
-              >
-                <Text fontSize={width / PIXEL_SIZE * 0.05} color={0x666666} textAlign="center">
-                  Enter Video URL
-                </Text>
-              </Container>
-            )}
-          </>
+        {!currentUrl && !hasError ? (
+          <Container
+            sizeX={width}
+            sizeY={screenHeight}
+            pixelSize={PIXEL_SIZE}
+            backgroundColor={0x000000}
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Text fontSize={width / PIXEL_SIZE * 0.05} color={0x666666} textAlign="center">
+              Enter Video URL
+            </Text>
+          </Container>
+        ) : !currentUrl || hasError ? (
+          <PlaceholderScreen width={width} screenHeight={screenHeight} color="#000000" />
         ) : (
           <ErrorBoundary
             fallback={<PlaceholderScreen width={width} screenHeight={screenHeight} color="#000000" />}


### PR DESCRIPTION
## Summary
- #145 の修正後もちらつきが残っていた（uikit Container と PlaceholderScreen が同じZ座標に重なるため）
- ガイドテキスト・リトライ表示時は PlaceholderScreen を描画せず、uikit Container の `backgroundColor` で黒背景を兼ねることでプレーンを1枚に統合
- 条件分岐を3分岐（リトライ中 / URL未設定 / 再生中）に整理

## Test plan
- [ ] LiveVideoPlayer: URL未設定時にちらつきなく「Enter Live Stream URL」が表示されること
- [ ] LiveVideoPlayer: 再接続中にちらつきなく「Reconnecting...」が表示されること
- [ ] VideoPlayer: URL未設定時にちらつきなく「Enter Video URL」が表示されること
- [ ] エラー時・Suspense fallback の PlaceholderScreen は従来通り表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)