### PR TITLE
fix: package-lock.json のバージョンを 0.34.0 に同期

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.32.2",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.32.2",
+      "version": "0.34.0",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",


### PR DESCRIPTION
## Summary
- `npm version minor` で `package.json` のみ更新され、`package-lock.json` のバージョンが `0.32.2` のまま残っていたのを `0.34.0` に同期

🤖 Generated with [Claude Code](https://claude.com/claude-code)