### PR TITLE
feat: TroikaText コンポーネントを追加

### DIFF
--- a/dev/main.tsx
+++ b/dev/main.tsx
@@ -2,7 +2,7 @@ import { createRoot } from 'react-dom/client'
 import { RigidBody } from '@react-three/rapier'
 import { DevEnvironment } from '../src/components/DevEnvironment'
 import { TextInputProvider, createDefaultTextInputImplementation } from '../src/contexts/TextInputContext'
-import { TestScene } from '../src/scenes/TestScene'
+import { TroikaTextScene } from '../src/scenes/TroikaTextScene'
 
 const textInput = createDefaultTextInputImplementation()
 
@@ -24,7 +24,7 @@ function App() {
       <directionalLight position={[5, 10, 5]} intensity={1} castShadow />
       <TextInputProvider value={textInput}>
         <Floor />
-        <TestScene />
+        <TroikaTextScene />
       </TextInputProvider>
     </DevEnvironment>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "jsdom": "^28.0.0",
         "react-dom": "^19.2.0",
         "three": "^0.181.0",
+        "troika-three-text": "^0.52.4",
         "typescript": "^5.6.3",
         "vitest": "^4.0.17"
       },
@@ -30,7 +31,8 @@
         "@react-three/uikit": "^1.0.0",
         "hls.js": "^1.5.0",
         "react": "^18.0.0 || ^19.0.0",
-        "three": ">=0.176.0"
+        "three": ">=0.176.0",
+        "troika-three-text": ">=0.49.0"
       },
       "peerDependenciesMeta": {
         "@react-three/rapier": {
@@ -40,6 +42,9 @@
           "optional": true
         },
         "hls.js": {
+          "optional": true
+        },
+        "troika-three-text": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "@react-three/uikit": "^1.0.0",
     "hls.js": "^1.5.0",
     "react": "^18.0.0 || ^19.0.0",
-    "three": ">=0.176.0"
+    "three": ">=0.176.0",
+    "troika-three-text": ">=0.49.0"
   },
   "peerDependenciesMeta": {
     "@react-three/rapier": {
@@ -48,6 +49,9 @@
       "optional": true
     },
     "hls.js": {
+      "optional": true
+    },
+    "troika-three-text": {
       "optional": true
     }
   },
@@ -64,6 +68,7 @@
     "react-dom": "^19.2.0",
     "three": "^0.181.0",
     "typescript": "^5.6.3",
+    "troika-three-text": "^0.52.4",
     "vitest": "^4.0.17"
   }
 }

--- a/src/components/TroikaText/index.tsx
+++ b/src/components/TroikaText/index.tsx
@@ -1,0 +1,81 @@
+import { Children, memo, useRef, useState, useEffect, useLayoutEffect, useMemo } from 'react'
+import { Content } from '@react-three/uikit'
+import { Content as VanillaContent } from '@pmndrs/uikit'
+import { Text as TroikaTextMesh, preloadFont } from 'troika-three-text'
+import { suspend } from 'suspend-react'
+import { useThree } from '@react-three/fiber'
+import type { Props } from './types'
+
+const DEFAULT_FONT_URL =
+  'https://cdn.jsdelivr.net/fontsource/fonts/noto-sans-jp@latest/japanese-400-normal.ttf'
+
+export type { Props as TroikaTextProps }
+
+export const TroikaText = memo(
+  ({
+    children,
+    fontSize = 16,
+    color,
+    font,
+    maxWidth,
+    textAlign,
+    lineHeight,
+    letterSpacing,
+    anchorX = 'left',
+    anchorY = 'top',
+    ...contentProps
+  }: Props) => {
+    const resolvedFont = font ?? DEFAULT_FONT_URL
+    const contentRef = useRef<VanillaContent>(null)
+    const invalidate = useThree(({ invalidate }) => invalidate)
+
+    const [troikaMesh] = useState(() => new TroikaTextMesh())
+
+    // フォントプリロード（Suspense 対応 — drei と同じパターン）
+    suspend(
+      () =>
+        new Promise<void>((res) =>
+          preloadFont({ font: resolvedFont }, () => res()),
+        ),
+      ['troika-font', resolvedFont],
+    )
+
+    // children からテキスト文字列を抽出（drei と同じパターン）
+    const text = useMemo(() => {
+      let t = ''
+      Children.forEach(children, (child) => {
+        if (typeof child === 'string' || typeof child === 'number') t += child
+      })
+      return t
+    }, [children])
+
+    // troika プロパティを設定して sync（毎レンダリング）
+    useLayoutEffect(() => {
+      troikaMesh.text = text
+      troikaMesh.font = resolvedFont
+      troikaMesh.fontSize = fontSize
+      if (color != null) troikaMesh.color = color as number
+      if (maxWidth != null) troikaMesh.maxWidth = maxWidth
+      if (textAlign != null) troikaMesh.textAlign = textAlign
+      if (lineHeight != null) troikaMesh.lineHeight = lineHeight
+      if (letterSpacing != null) troikaMesh.letterSpacing = letterSpacing
+      troikaMesh.anchorX = anchorX
+      troikaMesh.anchorY = anchorY
+
+      troikaMesh.sync(() => {
+        invalidate()
+        contentRef.current?.notifyAncestorsChanged()
+      })
+    })
+
+    useEffect(() => () => troikaMesh.dispose(), [troikaMesh])
+
+    return (
+      <Content ref={contentRef} keepAspectRatio={false} {...contentProps}>
+        <primitive object={troikaMesh} />
+      </Content>
+    )
+  },
+)
+
+TroikaText.displayName = 'TroikaText'

--- a/src/components/TroikaText/types.ts
+++ b/src/components/TroikaText/types.ts
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react'
+import type { ContentProperties } from '@react-three/uikit'
+import type { ReactThreeFiber } from '@react-three/fiber'
+
+/** ContentProperties と衝突するプロパティを除外（troika 用に再定義する） */
+type ContentBaseProps = Omit<
+  ContentProperties,
+  | 'children'
+  | 'color'
+  | 'fontSize'
+  | 'letterSpacing'
+  | 'lineHeight'
+  | 'textAlign'
+  | 'anchorX'
+  | 'anchorY'
+>
+
+export interface Props extends ContentBaseProps {
+  children: ReactNode
+  fontSize?: number
+  color?: ReactThreeFiber.Color
+  font?: string
+  maxWidth?: number
+  textAlign?: 'left' | 'right' | 'center' | 'justify'
+  lineHeight?: number | 'normal'
+  letterSpacing?: number
+  anchorX?: number | 'left' | 'center' | 'right'
+  anchorY?:
+    | number
+    | 'top'
+    | 'top-baseline'
+    | 'middle'
+    | 'bottom-baseline'
+    | 'bottom'
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,8 @@ export {
 
 export { Portal, type PortalProps } from './components/Portal'
 
+export { TroikaText, type TroikaTextProps } from './components/TroikaText'
+
 export {
   BillboardY,
   useBillboardY,

--- a/src/scenes/TroikaTextScene.tsx
+++ b/src/scenes/TroikaTextScene.tsx
@@ -1,0 +1,48 @@
+import { Suspense } from 'react'
+import { Fullscreen, Container } from '@react-three/uikit'
+import { TroikaText } from '../components/TroikaText'
+
+export function TroikaTextScene() {
+  return (
+    <Suspense fallback={null}>
+      <Fullscreen flexDirection="column" alignItems="center" gap={20} pixelSize={0.01} paddingTop={100}>
+        {/* 単体テスト */}
+        <TroikaText fontSize={32} color={0x333333}>
+          こんにちは世界！Hello World!
+        </TroikaText>
+
+        {/* flexbox レイアウトテスト */}
+        <Container flexDirection="row" gap={10} alignItems="center">
+          <TroikaText fontSize={24} color={0x666666}>
+            URLを入力してください
+          </TroikaText>
+          <Container width={200} height={40} backgroundColor={0x3b82f6} borderRadius={4} />
+        </Container>
+
+        {/* 複数行テスト */}
+        <Container width={400} padding={16} backgroundColor={0xf3f4f6} borderRadius={8}>
+          <TroikaText fontSize={18} color={0x374151}>
+            日本語テキストのテスト。troika-three-text を使用して、charset
+            指定なしで日本語を表示しています。改行も自動で行われます。
+          </TroikaText>
+        </Container>
+
+        {/* fontSize / color バリエーション */}
+        <Container flexDirection="row" gap={16} alignItems="flex-end">
+          <TroikaText fontSize={12} color={0x9ca3af}>
+            12px
+          </TroikaText>
+          <TroikaText fontSize={18} color={0x6b7280}>
+            18px
+          </TroikaText>
+          <TroikaText fontSize={24} color={0x374151}>
+            24px
+          </TroikaText>
+          <TroikaText fontSize={32} color={0x111827}>
+            32px
+          </TroikaText>
+        </Container>
+      </Fullscreen>
+    </Suspense>
+  )
+}

--- a/src/types/troika-three-text.d.ts
+++ b/src/types/troika-three-text.d.ts
@@ -1,0 +1,42 @@
+declare module 'troika-three-text' {
+  import { Mesh, Color, Material } from 'three'
+
+  export class Text extends Mesh {
+    text: string
+    font: string | null
+    fontSize: number
+    color: string | number | Color | null
+    maxWidth: number
+    textAlign: 'left' | 'right' | 'center' | 'justify'
+    anchorX: number | 'left' | 'center' | 'right'
+    anchorY:
+      | number
+      | 'top'
+      | 'top-baseline'
+      | 'middle'
+      | 'bottom-baseline'
+      | 'bottom'
+    letterSpacing: number
+    lineHeight: number | 'normal'
+    whiteSpace: 'normal' | 'nowrap'
+    overflowWrap: 'normal' | 'break-word'
+    direction: 'auto' | 'ltr' | 'rtl'
+    fontWeight: number | 'normal' | 'bold'
+    fontStyle: 'normal' | 'italic'
+    outlineWidth: number | string
+    outlineColor: string | number | Color
+    outlineOpacity: number
+    fillOpacity: number
+    sdfGlyphSize: number
+    material: Material | null
+    depthOffset: number
+    clipRect: [number, number, number, number] | null
+    sync(callback?: () => void): void
+    dispose(): void
+  }
+
+  export function preloadFont(
+    options: { font?: string | null; characters?: string | string[] },
+    callback?: () => void,
+  ): void
+}


### PR DESCRIPTION
## Summary

- `troika-three-text` を uikit の `Content` コンポーネントでラップした `TroikaText` コンポーネントを追加
- charset 指定不要で日本語テキストを flexbox レイアウト内に表示可能
- デフォルトフォントとして Noto Sans JP を使用（`font` prop でカスタマイズ可能）

## 新規ファイル

| ファイル | 内容 |
|---------|------|
| `src/types/troika-three-text.d.ts` | troika-three-text の TypeScript 型宣言 |
| `src/components/TroikaText/types.ts` | Props 型定義 |
| `src/components/TroikaText/index.tsx` | メインコンポーネント |
| `src/scenes/TroikaTextScene.tsx` | 動作確認用テストシーン（ビルド対象外） |

## 使い方

```tsx
<Container flexDirection="row" gap={10} pixelSize={0.01}>
  <TroikaText fontSize={24} color={0x666666}>
    URLを入力してください
  </TroikaText>
  <Container width={100} height={50} backgroundColor="blue" />
</Container>
```

## Test plan

- [x] `npm run build` — ビルド通過
- [x] `npm test` — 全 210 テスト通過
- [ ] `npm run dev` でブラウザ上の動作確認
  - TroikaText が Container 内で flexbox レイアウトに参加するか
  - 日本語テキストが charset 指定なしで表示されるか
  - fontSize, color の変更が反映されるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)