### PR TITLE
fix(Mirror): VR モードで鏡が灰色になる問題を修正

### DIFF
--- a/src/components/Mirror/index.tsx
+++ b/src/components/Mirror/index.tsx
@@ -10,6 +10,7 @@ import { shouldUseReflector } from './utils'
 export type { MirrorProps } from './types'
 
 const _worldPos = new Vector3()
+const _cameraWorldPos = new Vector3()
 
 const fallbackVertexShader = `
   varying vec3 vWorldNormal;
@@ -109,14 +110,19 @@ export function Mirror({
   // VRMFirstPersonのレイヤー設定により、メインカメラではThirdPersonOnlyレイヤー（頭部）が
   // 非表示になっているが、鏡には全身を映す必要があるため
   // onBeforeRenderでメインカメラの設定がコピーされるため、毎フレーム設定が必要
-  useFrame(({ camera }) => {
+  useFrame(({ camera, gl }) => {
     const reflector = reflectorRef.current
     if (!reflector) return
 
     // LOD: カメラと鏡の距離に応じて Reflector ↔ envMap を切り替え
     const fallback = fallbackRef.current
     if (fallback && groupRef.current) {
-      const distance = camera.position.distanceTo(groupRef.current.getWorldPosition(_worldPos))
+      // VR モードでは XR カメラのワールド座標を使用
+      const activeCamera = gl.xr.isPresenting ? gl.xr.getCamera() : camera
+      _cameraWorldPos.setFromMatrixPosition(activeCamera.matrixWorld)
+      const distance = _cameraWorldPos.distanceTo(
+        groupRef.current.getWorldPosition(_worldPos),
+      )
       const useReflector = shouldUseReflector(
         distance,
         lodDistance,


### PR DESCRIPTION
## Summary

- VR モードで Mirror コンポーネントが灰色の単色表示になる問題を修正
- LOD 距離計算で `camera.position`（ローカル座標）を使用していたため、XR リグの子になる VR カメラでは実際のワールド座標と大きく乖離していた
- `gl.xr.isPresenting` 時は `gl.xr.getCamera()` で XR カメラを取得し、`setFromMatrixPosition(matrixWorld)` でワールド座標に統一して距離計算するように修正

## Test plan

- [ ] 非VR: ミラーに近づく/離れる → LOD 切り替え動作確認（既存動作の維持）
- [ ] VR (Quest): ミラーに近づいた時に灰色ではなく反射が表示されること
- [ ] `npm run build` ✅
- [ ] `vitest run` ✅ (210 tests passed)

## 補足

LOD 修正後も VR で単色が続く場合は、Three.js Reflector の render target 処理が Quest の WebXR 環境で正しく動作していない可能性があり、Phase 2 として別途調査が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)