### PR TITLE
chore: bump version to 0.35.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.34.0",
+  "version": "0.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xrift/world-components",
-      "version": "0.34.0",
+      "version": "0.35.1",
       "license": "MIT",
       "devDependencies": {
         "@react-three/drei": "^10.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- パッチバージョンを 0.35.0 → 0.35.1 に更新
- package-lock.json のバージョンも 0.34.0 → 0.35.1 に同期

🤖 Generated with [Claude Code](https://claude.com/claude-code)