### PR TITLE
fix(ScreenShareDisplay): リモート画面共有時に PlaneGeometry の width が NaN になる問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.35.4",
+  "version": "0.35.5",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/ScreenShareDisplay/__tests__/utils.test.ts
+++ b/src/components/ScreenShareDisplay/__tests__/utils.test.ts
@@ -32,4 +32,22 @@ describe('calculateContainSize', () => {
     expect(h).toBe(2.25)
     expect(w).toBeCloseTo(2.25)
   })
+
+  it('videoWidth と videoHeight が共に 0 の場合はスクリーンサイズを返す', () => {
+    const [w, h] = calculateContainSize(0, 0, 4, 2.25)
+    expect(w).toBe(4)
+    expect(h).toBe(2.25)
+  })
+
+  it('videoWidth のみ 0 の場合はスクリーンサイズを返す', () => {
+    const [w, h] = calculateContainSize(0, 1080, 4, 2.25)
+    expect(w).toBe(4)
+    expect(h).toBe(2.25)
+  })
+
+  it('videoHeight のみ 0 の場合はスクリーンサイズを返す', () => {
+    const [w, h] = calculateContainSize(1920, 0, 4, 2.25)
+    expect(w).toBe(4)
+    expect(h).toBe(2.25)
+  })
 })

--- a/src/components/ScreenShareDisplay/hooks.ts
+++ b/src/components/ScreenShareDisplay/hooks.ts
@@ -36,18 +36,24 @@ export const useVideoTexture = (
     setTexture(videoTexture)
 
     // 映像のメタデータがロードされたら解像度を記録
+    // WebRTC リモートトラックでは loadedmetadata 時に videoWidth/Height が 0 のケースがあるため、
+    // ゼロチェックを行い、resize イベントでも解像度確定を監視する
     const handleLoadedMetadata = () => {
-      setVideoResolution([videoElement.videoWidth, videoElement.videoHeight])
+      if (videoElement.videoWidth > 0 && videoElement.videoHeight > 0) {
+        setVideoResolution([videoElement.videoWidth, videoElement.videoHeight])
+      }
     }
 
-    if (videoElement.videoWidth > 0) {
+    if (videoElement.videoWidth > 0 && videoElement.videoHeight > 0) {
       handleLoadedMetadata()
     } else {
       videoElement.addEventListener('loadedmetadata', handleLoadedMetadata)
+      videoElement.addEventListener('resize', handleLoadedMetadata)
     }
 
     return () => {
       videoElement.removeEventListener('loadedmetadata', handleLoadedMetadata)
+      videoElement.removeEventListener('resize', handleLoadedMetadata)
       videoTexture.dispose()
     }
   }, [videoElement])

--- a/src/components/ScreenShareDisplay/utils.ts
+++ b/src/components/ScreenShareDisplay/utils.ts
@@ -7,6 +7,8 @@ export const calculateContainSize = (
   screenWidth: number,
   screenHeight: number,
 ): [number, number] => {
+  if (videoWidth <= 0 || videoHeight <= 0) return [screenWidth, screenHeight]
+
   const videoAspect = videoWidth / videoHeight
   const screenAspect = screenWidth / screenHeight
 


### PR DESCRIPTION
## Summary

- WebRTC リモートトラック受信時、`loadedmetadata` イベント発火時点で `videoWidth/videoHeight` が `0` のケースがあり、`calculateContainSize` で `0/0 = NaN` が発生して PlaneGeometry にエラーが出る問題を修正
- `hooks.ts`: `handleLoadedMetadata` でゼロチェック追加 + `resize` イベント監視で解像度確定を検知
- `utils.ts`: `calculateContainSize` にゼロ入力の防御的ガード追加（`screenSize` フォールバック）
- テスト: ゼロ入力ケース3パターン追加

## Test plan

- [x] `pnpm test` で既存テスト + 新規テスト（213件）がすべてパス
- [ ] リモート画面共有で PlaneGeometry に NaN が渡らないことを実機確認

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)