### PR TITLE
feat(DevEnvironment): outputBufferType prop を追加して開発プレビューに反映

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/DevEnvironment/__tests__/utils.test.ts
+++ b/src/components/DevEnvironment/__tests__/utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { FloatType, HalfFloatType, UnsignedByteType } from 'three'
+import { toThreeOutputBufferType } from '../utils'
+
+describe('toThreeOutputBufferType', () => {
+  it('HalfFloatType 文字列を Three.js の HalfFloatType に変換する', () => {
+    expect(toThreeOutputBufferType('HalfFloatType')).toBe(HalfFloatType)
+  })
+
+  it('FloatType 文字列を Three.js の FloatType に変換する', () => {
+    expect(toThreeOutputBufferType('FloatType')).toBe(FloatType)
+  })
+
+  it('UnsignedByteType 文字列を Three.js の UnsignedByteType に変換する', () => {
+    expect(toThreeOutputBufferType('UnsignedByteType')).toBe(UnsignedByteType)
+  })
+
+  it('null の場合は undefined を返す', () => {
+    expect(toThreeOutputBufferType(null)).toBeUndefined()
+  })
+
+  it('undefined の場合は undefined を返す', () => {
+    expect(toThreeOutputBufferType(undefined)).toBeUndefined()
+  })
+
+  it('未知の文字列の場合は undefined を返す', () => {
+    expect(toThreeOutputBufferType('InvalidType')).toBeUndefined()
+  })
+})

--- a/src/components/DevEnvironment/index.tsx
+++ b/src/components/DevEnvironment/index.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useState, useSyncExternalStore } from 'react'
+import { useCallback, useMemo, useState, useSyncExternalStore } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { PointerLockControls } from '@react-three/drei'
 import { Physics } from '@react-three/rapier'
 import { SpawnPointProvider } from '../../contexts/SpawnPointContext'
 import { PCFShadowMap } from 'three'
 import type { Props } from './types'
+import { toThreeOutputBufferType } from './utils'
 import {
   DEFAULT_SPAWN_POSITION,
   DEFAULT_GRAVITY,
@@ -47,6 +48,7 @@ export function DevEnvironment({
   spawnPosition = DEFAULT_SPAWN_POSITION,
   respawnThreshold = RESPAWN_Y_THRESHOLD,
   physicsConfig,
+  outputBufferType: outputBufferTypeStr,
 }: Props) {
   const [isHit, setIsHit] = useState(false)
   const isPointerLocked = useSyncExternalStore(
@@ -59,6 +61,15 @@ export function DevEnvironment({
   const gravity = physicsConfig?.gravity ?? DEFAULT_GRAVITY
   const allowInfiniteJump =
     physicsConfig?.allowInfiniteJump ?? DEFAULT_ALLOW_INFINITE_JUMP
+
+  const outputBufferType = toThreeOutputBufferType(outputBufferTypeStr)
+  const glProps = useMemo(
+    () =>
+      outputBufferType
+        ? { preserveDrawingBuffer: true, stencil: true, outputBufferType }
+        : { preserveDrawingBuffer: true, stencil: true },
+    [outputBufferType],
+  )
 
   const cameraPosition = camera?.position ?? spawnPosition
   const cameraFov = camera?.fov ?? 50
@@ -75,7 +86,7 @@ export function DevEnvironment({
           near: cameraNear,
           far: cameraFar,
         }}
-        gl={{ preserveDrawingBuffer: true }}
+        gl={glProps}
       >
         <PointerLockControls />
         <CenterRaycaster onHitChange={handleHitChange} />

--- a/src/components/DevEnvironment/types.ts
+++ b/src/components/DevEnvironment/types.ts
@@ -28,4 +28,6 @@ export interface Props {
   respawnThreshold?: number
   /** 物理設定 */
   physicsConfig?: PhysicsConfig
+  /** 出力バッファタイプ（"UnsignedByteType" | "HalfFloatType" | "FloatType"） */
+  outputBufferType?: string
 }

--- a/src/components/DevEnvironment/utils.ts
+++ b/src/components/DevEnvironment/utils.ts
@@ -1,0 +1,17 @@
+import {
+  FloatType,
+  HalfFloatType,
+  type TextureDataType,
+  UnsignedByteType,
+} from 'three'
+
+const OUTPUT_BUFFER_TYPE_MAP: Record<string, TextureDataType> = {
+  UnsignedByteType,
+  HalfFloatType,
+  FloatType,
+}
+
+export function toThreeOutputBufferType(value: string | null | undefined): TextureDataType | undefined {
+  if (!value) return undefined
+  return OUTPUT_BUFFER_TYPE_MAP[value]
+}


### PR DESCRIPTION
## Summary
- `DevEnvironment` に `outputBufferType` prop を追加し、Canvas の `gl` prop に動的適用
- xrift-frontend PR #1191 と同じパターンで、文字列→Three.js `TextureDataType` 変換を行う純粋関数 `toThreeOutputBufferType` を実装
- 単体テスト6件を追加

## 関連
- WebXR-JP/xrift-frontend#1191
- https://docs.xrift.net/guides/configuration#outputbuffertype

## Test plan
- [x] `toThreeOutputBufferType` のユニットテスト（6件通過）
- [ ] `<DevEnvironment outputBufferType="HalfFloatType">` で開発プレビューの描画が変わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)