### PR TITLE
feat(UsersContext): アバター高さ情報を取得する API を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/contexts/UsersContext.tsx
+++ b/src/contexts/UsersContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, type ReactNode, useContext } from 'react'
+import type { AvatarHeight } from '../types/avatar'
 import type { PlayerMovement } from '../types/movement'
 
 /**
@@ -29,6 +30,14 @@ const DEFAULT_PLAYER_MOVEMENT: PlayerMovement = {
 }
 
 /**
+ * デフォルトの AvatarHeight（高さ情報が取得できない場合に使用）
+ */
+const DEFAULT_AVATAR_HEIGHT: AvatarHeight = {
+  height: 1.5,
+  eyeHeight: 1.35,
+}
+
+/**
  * ユーザー情報を管理するためのインターフェース
  * プラットフォーム側（xrift-frontend）が実装を注入する
  */
@@ -50,6 +59,17 @@ export interface UsersContextValue {
    * @returns PlayerMovement
    */
   getLocalMovement: () => PlayerMovement
+  /**
+   * 指定したユーザーのアバター高さ情報を取得
+   * @param userId - ユーザーの一意識別子
+   * @returns AvatarHeight または undefined（ユーザーが存在しない場合）
+   */
+  getAvatarHeight?: (userId: string) => AvatarHeight | undefined
+  /**
+   * ローカルユーザー（自分）のアバター高さ情報を取得
+   * @returns AvatarHeight
+   */
+  getLocalAvatarHeight?: () => AvatarHeight
 }
 
 /**
@@ -61,6 +81,8 @@ const createDefaultImplementation = (): UsersContextValue => ({
   remoteUsers: [],
   getMovement: () => undefined,
   getLocalMovement: () => DEFAULT_PLAYER_MOVEMENT,
+  getAvatarHeight: () => undefined,
+  getLocalAvatarHeight: () => DEFAULT_AVATAR_HEIGHT,
 })
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,6 +193,8 @@ export { useDefaultFont, type FontLocale } from './hooks/useDefaultFont'
 export { LAYERS, type LayerName, type LayerNumber } from './constants/layers'
 
 // Types
+export { type AvatarHeight } from './types/avatar'
+
 export {
   type PlayerMovement,
   type Position3D,

--- a/src/types/avatar.ts
+++ b/src/types/avatar.ts
@@ -1,0 +1,6 @@
+export interface AvatarHeight {
+  /** アバターの全身の高さ（メートル） */
+  height: number
+  /** 地面からアバターの目の位置までの高さ（メートル） */
+  eyeHeight: number
+}


### PR DESCRIPTION
## Summary
- `AvatarHeight` インターフェース（`height`, `eyeHeight`）を `src/types/avatar.ts` に新規作成
- `UsersContextValue` に `getAvatarHeight` / `getLocalAvatarHeight` を optional プロパティとして追加
- デフォルト値: height=1.5m, eyeHeight=1.35m
- 破壊的変更なし（全て optional プロパティ）

## Test plan
- [x] `npm run build` (tsc) でビルドが通ること
- [x] `npm test` で全228テストがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)