### PR TITLE
feat: useFileInput hooks を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.37.1",
+  "version": "0.38.0",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/contexts/FileInputContext.tsx
+++ b/src/contexts/FileInputContext.tsx
@@ -1,0 +1,126 @@
+import { createContext, useContext, type ReactNode } from 'react'
+
+/**
+ * ファイル入力のエラー種別
+ */
+export type FileInputErrorType = 'file_too_large' | 'invalid_type'
+
+/**
+ * ファイル入力のエラー情報
+ */
+export interface FileInputError {
+  type: FileInputErrorType
+  message: string
+}
+
+/**
+ * ファイル入力のリクエスト情報
+ */
+export interface FileInputRequest {
+  /** 入力の一意なID */
+  id: string
+  /** 受け入れるファイルタイプ（例: '.vrm', 'image/*'） */
+  accept?: string
+  /** 複数ファイル選択を許可するか */
+  multiple?: boolean
+  /** 最大ファイルサイズ（バイト単位） */
+  maxSize?: number
+  /** ファイル選択完了時のコールバック */
+  onSelect: (files: File[]) => void
+  /** キャンセル時のコールバック */
+  onCancel?: () => void
+  /** エラー時のコールバック */
+  onError?: (error: FileInputError) => void
+}
+
+/**
+ * ファイル入力のContext値
+ */
+export interface FileInputContextValue {
+  /**
+   * ファイル選択ダイアログを表示する
+   * xrift-frontend側でオーバーレイUIを表示し、ファイル選択後にonSelectが呼ばれる
+   */
+  requestFileInput: (request: FileInputRequest) => void
+  /**
+   * 現在アクティブなファイル入力があるか
+   */
+  isActive: boolean
+}
+
+/**
+ * デフォルトの実装（開発環境用）
+ * 動的にinput[type=file]を作成してファイル選択する
+ */
+export const createDefaultFileInputImplementation = (): FileInputContextValue => ({
+  requestFileInput: (request) => {
+    console.log('[FileInput] requestFileInput called:', request)
+    const input = document.createElement('input')
+    input.type = 'file'
+    if (request.accept) input.accept = request.accept
+    if (request.multiple) input.multiple = true
+
+    input.addEventListener('change', () => {
+      const files = Array.from(input.files ?? [])
+      if (files.length === 0) {
+        request.onCancel?.()
+        return
+      }
+      if (request.maxSize) {
+        const oversized = files.find((f) => f.size > request.maxSize!)
+        if (oversized) {
+          request.onError?.({
+            type: 'file_too_large',
+            message: `File "${oversized.name}" exceeds max size of ${request.maxSize} bytes`,
+          })
+          return
+        }
+      }
+      request.onSelect(files)
+    })
+
+    input.click()
+  },
+  isActive: false,
+})
+
+/**
+ * ファイル入力のContext
+ */
+export const FileInputContext = createContext<FileInputContextValue | null>(null)
+
+interface Props {
+  value: FileInputContextValue
+  children: ReactNode
+}
+
+/**
+ * ファイル入力のContextProvider
+ */
+export const FileInputProvider = ({ value, children }: Props) => {
+  return <FileInputContext.Provider value={value}>{children}</FileInputContext.Provider>
+}
+
+/**
+ * ファイル入力の機能を取得するhook
+ *
+ * @example
+ * const { requestFileInput } = useFileInputContext()
+ * requestFileInput({
+ *   id: 'avatar-upload',
+ *   accept: '.vrm',
+ *   maxSize: 30 * 1024 * 1024,
+ *   onSelect: (files) => console.log('選択されたファイル:', files),
+ * })
+ *
+ * @throws {Error} FileInputProvider の外で呼び出された場合
+ */
+export const useFileInputContext = (): FileInputContextValue => {
+  const context = useContext(FileInputContext)
+
+  if (!context) {
+    throw new Error('useFileInputContext must be used within FileInputProvider')
+  }
+
+  return context
+}

--- a/src/contexts/XRiftContext.tsx
+++ b/src/contexts/XRiftContext.tsx
@@ -28,6 +28,11 @@ import {
   createDefaultTextInputImplementation,
   type TextInputContextValue,
 } from './TextInputContext'
+import {
+  FileInputProvider,
+  createDefaultFileInputImplementation,
+  type FileInputContextValue,
+} from './FileInputContext'
 import { UsersProvider, type UsersContextValue } from './UsersContext'
 import {
   InstanceEventProvider,
@@ -139,6 +144,11 @@ interface Props {
    */
   audioVolumeImplementation?: AudioVolumeContextValue
   /**
+   * ファイル入力の実装（オプション）
+   * 指定しない場合はデフォルト実装（ブラウザのファイル選択）が使用される
+   */
+  fileInputImplementation?: FileInputContextValue
+  /**
    * アイテムの配置状態（オプション）
    * 'preview': プレビュー中、'placed': 設置済み
    * 指定しない場合は Provider をスキップ（フォールバックで 'placed' が返る）
@@ -165,6 +175,7 @@ export const XRiftProvider = ({
   worldImplementation,
   instanceEventImplementation,
   audioVolumeImplementation,
+  fileInputImplementation,
   placementMode,
   children,
 }: Props) => {
@@ -219,6 +230,12 @@ export const XRiftProvider = ({
     [audioVolumeImplementation],
   )
 
+  // ファイル入力の実装（指定がない場合はデフォルト実装を使用）
+  const fileInputImpl = useMemo(
+    () => fileInputImplementation ?? createDefaultFileInputImplementation(),
+    [fileInputImplementation],
+  )
+
   // オブジェクトの登録
   const registerInteractable = useCallback((object: Object3D) => {
     interactableObjects.add(object)
@@ -240,31 +257,33 @@ export const XRiftProvider = ({
     <XRiftContext.Provider value={xriftContextValue}>
       <ScreenShareProvider value={screenShareImpl}>
         <TextInputProvider value={textInputImpl}>
-          <InstanceStateProvider implementation={instanceStateImplementation}>
-            <SpawnPointProvider implementation={spawnPointImplementation}>
-              <UsersProvider implementation={usersImplementation}>
-                <InstanceEventProvider value={instanceEventImpl}>
-                  <TeleportProvider value={teleportImpl}>
-                    <ConfirmProvider value={confirmImpl}>
-                      <WorldProvider value={worldImpl}>
-                        <InstanceProvider value={instanceImpl}>
-                          <AudioVolumeProvider value={audioVolumeImpl}>
-                            {placementMode ? (
-                              <PlacementStateProvider mode={placementMode}>
-                                {children}
-                              </PlacementStateProvider>
-                            ) : (
-                              children
-                            )}
-                          </AudioVolumeProvider>
-                        </InstanceProvider>
-                      </WorldProvider>
-                    </ConfirmProvider>
-                  </TeleportProvider>
-                </InstanceEventProvider>
-              </UsersProvider>
-            </SpawnPointProvider>
-          </InstanceStateProvider>
+          <FileInputProvider value={fileInputImpl}>
+            <InstanceStateProvider implementation={instanceStateImplementation}>
+              <SpawnPointProvider implementation={spawnPointImplementation}>
+                <UsersProvider implementation={usersImplementation}>
+                  <InstanceEventProvider value={instanceEventImpl}>
+                    <TeleportProvider value={teleportImpl}>
+                      <ConfirmProvider value={confirmImpl}>
+                        <WorldProvider value={worldImpl}>
+                          <InstanceProvider value={instanceImpl}>
+                            <AudioVolumeProvider value={audioVolumeImpl}>
+                              {placementMode ? (
+                                <PlacementStateProvider mode={placementMode}>
+                                  {children}
+                                </PlacementStateProvider>
+                              ) : (
+                                children
+                              )}
+                            </AudioVolumeProvider>
+                          </InstanceProvider>
+                        </WorldProvider>
+                      </ConfirmProvider>
+                    </TeleportProvider>
+                  </InstanceEventProvider>
+                </UsersProvider>
+              </SpawnPointProvider>
+            </InstanceStateProvider>
+          </FileInputProvider>
         </TextInputProvider>
       </ScreenShareProvider>
     </XRiftContext.Provider>

--- a/src/hooks/useFileInput.ts
+++ b/src/hooks/useFileInput.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react'
+import { type FileInputRequest, useFileInputContext } from '../contexts/FileInputContext'
+
+/**
+ * ファイル選択ダイアログを使用するhook
+ * ワールド作成者が3Dオブジェクトのクリックをトリガーにファイル選択を行うために使用
+ *
+ * @example
+ * const { requestFileInput } = useFileInput()
+ *
+ * const handleClick = () => {
+ *   requestFileInput({
+ *     id: 'avatar-upload',
+ *     accept: '.vrm',
+ *     maxSize: 30 * 1024 * 1024,
+ *     onSelect: (files) => console.log('選択されたファイル:', files),
+ *   })
+ * }
+ *
+ * @returns {{ requestFileInput: (request: FileInputRequest) => void }}
+ */
+export const useFileInput = (): { requestFileInput: (request: FileInputRequest) => void } => {
+  const { requestFileInput } = useFileInputContext()
+
+  const stableRequestFileInput = useCallback(
+    (request: FileInputRequest) => {
+      requestFileInput(request)
+    },
+    [requestFileInput],
+  )
+
+  return { requestFileInput: stableRequestFileInput }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,17 @@ export {
 } from './contexts/TextInputContext'
 
 export {
+  FileInputContext,
+  FileInputProvider,
+  useFileInputContext,
+  createDefaultFileInputImplementation,
+  type FileInputContextValue,
+  type FileInputRequest,
+  type FileInputError,
+  type FileInputErrorType,
+} from './contexts/FileInputContext'
+
+export {
   ConfirmContext,
   ConfirmProvider,
   useConfirmContext,
@@ -182,6 +193,7 @@ export {
 export { useInstanceState } from './hooks/useInstanceState'
 export { useSpawnPoint } from './hooks/useSpawnPoint'
 export { useConfirm } from './hooks/useConfirm'
+export { useFileInput } from './hooks/useFileInput'
 export { useTeleport } from './hooks/useTeleport'
 export { useInstance } from './hooks/useInstance'
 export { useWorld } from './hooks/useWorld'


### PR DESCRIPTION
## Summary
- `FileInputContext.tsx` を新規追加（型定義・デフォルト実装・Provider・hook）
- `useFileInput.ts` convenience hook を新規追加
- `XRiftContext.tsx` に `fileInputImplementation` prop を追加し Provider ツリーに統合
- `index.ts` にエクスポート追加

## API
```typescript
// ワールド側での使用例
const { requestFileInput } = useFileInput()

requestFileInput({
  id: 'avatar-upload',
  accept: '.vrm',
  maxSize: 30 * 1024 * 1024,
  onSelect: (files) => { /* ファイル処理 */ },
  onCancel: () => { /* キャンセル */ },
  onError: (error) => { /* エラー処理 */ },
})
```

## 関連PR
- xrift-frontend: https://github.com/WebXR-JP/xrift-frontend/pull/1215

## Test plan
- [x] `npm run build` が通ること
- [ ] デフォルト実装（`createDefaultFileInputImplementation`）でファイルピッカーが開き File が返ること
- [ ] xrift-frontend 側と統合して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)