### PR TITLE
feat: 共有ファイル操作のContext・hookを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/contexts/SharedFileContext.tsx
+++ b/src/contexts/SharedFileContext.tsx
@@ -1,0 +1,89 @@
+import { createContext, useContext, type ReactNode } from 'react'
+
+/**
+ * 共有ファイルの情報
+ */
+export interface SharedFileInfo {
+  id: string
+  fileName: string
+  contentType: string
+  fileSize: number
+  publicUrl: string
+  createdAt: string
+}
+
+/**
+ * 共有ファイルのContext値
+ */
+export interface SharedFileContextValue {
+  /**
+   * ファイルをアップロードし、結果を返す
+   */
+  uploadSharedFile: (
+    file: File,
+    onProgress?: (progress: number) => void,
+  ) => Promise<SharedFileInfo>
+  /**
+   * 共有ファイル一覧を取得する
+   */
+  getSharedFiles: () => Promise<SharedFileInfo[]>
+}
+
+/**
+ * デフォルトの実装（開発環境用）
+ * console.log + ダミーデータを返す
+ */
+export const createDefaultSharedFileImplementation = (): SharedFileContextValue => ({
+  uploadSharedFile: async (file) => {
+    console.log('[SharedFile] uploadSharedFile called:', file.name)
+    return {
+      id: 'dummy-id',
+      fileName: file.name,
+      contentType: file.type,
+      fileSize: file.size,
+      publicUrl: `https://example.com/shared/${file.name}`,
+      createdAt: new Date().toISOString(),
+    }
+  },
+  getSharedFiles: async () => {
+    console.log('[SharedFile] getSharedFiles called')
+    return []
+  },
+})
+
+/**
+ * 共有ファイルのContext
+ */
+export const SharedFileContext = createContext<SharedFileContextValue | null>(null)
+
+interface Props {
+  value: SharedFileContextValue
+  children: ReactNode
+}
+
+/**
+ * 共有ファイルのContextProvider
+ */
+export const SharedFileProvider = ({ value, children }: Props) => {
+  return <SharedFileContext.Provider value={value}>{children}</SharedFileContext.Provider>
+}
+
+/**
+ * 共有ファイルの機能を取得するhook
+ *
+ * @example
+ * const { uploadSharedFile, getSharedFiles } = useSharedFileContext()
+ * const result = await uploadSharedFile(file, (progress) => console.log(progress))
+ * console.log('URL:', result.publicUrl)
+ *
+ * @throws {Error} SharedFileProvider の外で呼び出された場合
+ */
+export const useSharedFileContext = (): SharedFileContextValue => {
+  const context = useContext(SharedFileContext)
+
+  if (!context) {
+    throw new Error('useSharedFileContext must be used within SharedFileProvider')
+  }
+
+  return context
+}

--- a/src/contexts/XRiftContext.tsx
+++ b/src/contexts/XRiftContext.tsx
@@ -45,6 +45,11 @@ import {
   createDefaultAudioVolumeImplementation,
   type AudioVolumeContextValue,
 } from './AudioVolumeContext'
+import {
+  SharedFileProvider,
+  createDefaultSharedFileImplementation,
+  type SharedFileContextValue,
+} from './SharedFileContext'
 
 // デフォルトの画面共有実装（開発環境用）
 const createDefaultScreenShareImplementation = (): ScreenShareContextValue => ({
@@ -149,6 +154,11 @@ interface Props {
    */
   fileInputImplementation?: FileInputContextValue
   /**
+   * 共有ファイルの実装（オプション）
+   * 指定しない場合はデフォルト実装（console.log）が使用される
+   */
+  sharedFileImplementation?: SharedFileContextValue
+  /**
    * アイテムの配置状態（オプション）
    * 'preview': プレビュー中、'placed': 設置済み
    * 指定しない場合は Provider をスキップ（フォールバックで 'placed' が返る）
@@ -176,6 +186,7 @@ export const XRiftProvider = ({
   instanceEventImplementation,
   audioVolumeImplementation,
   fileInputImplementation,
+  sharedFileImplementation,
   placementMode,
   children,
 }: Props) => {
@@ -236,6 +247,12 @@ export const XRiftProvider = ({
     [fileInputImplementation],
   )
 
+  // 共有ファイルの実装（指定がない場合はデフォルト実装を使用）
+  const sharedFileImpl = useMemo(
+    () => sharedFileImplementation ?? createDefaultSharedFileImplementation(),
+    [sharedFileImplementation],
+  )
+
   // オブジェクトの登録
   const registerInteractable = useCallback((object: Object3D) => {
     interactableObjects.add(object)
@@ -258,31 +275,33 @@ export const XRiftProvider = ({
       <ScreenShareProvider value={screenShareImpl}>
         <TextInputProvider value={textInputImpl}>
           <FileInputProvider value={fileInputImpl}>
-            <InstanceStateProvider implementation={instanceStateImplementation}>
-              <SpawnPointProvider implementation={spawnPointImplementation}>
-                <UsersProvider implementation={usersImplementation}>
-                  <InstanceEventProvider value={instanceEventImpl}>
-                    <TeleportProvider value={teleportImpl}>
-                      <ConfirmProvider value={confirmImpl}>
-                        <WorldProvider value={worldImpl}>
-                          <InstanceProvider value={instanceImpl}>
-                            <AudioVolumeProvider value={audioVolumeImpl}>
-                              {placementMode ? (
-                                <PlacementStateProvider mode={placementMode}>
-                                  {children}
-                                </PlacementStateProvider>
-                              ) : (
-                                children
-                              )}
-                            </AudioVolumeProvider>
-                          </InstanceProvider>
-                        </WorldProvider>
-                      </ConfirmProvider>
-                    </TeleportProvider>
-                  </InstanceEventProvider>
-                </UsersProvider>
-              </SpawnPointProvider>
-            </InstanceStateProvider>
+            <SharedFileProvider value={sharedFileImpl}>
+              <InstanceStateProvider implementation={instanceStateImplementation}>
+                <SpawnPointProvider implementation={spawnPointImplementation}>
+                  <UsersProvider implementation={usersImplementation}>
+                    <InstanceEventProvider value={instanceEventImpl}>
+                      <TeleportProvider value={teleportImpl}>
+                        <ConfirmProvider value={confirmImpl}>
+                          <WorldProvider value={worldImpl}>
+                            <InstanceProvider value={instanceImpl}>
+                              <AudioVolumeProvider value={audioVolumeImpl}>
+                                {placementMode ? (
+                                  <PlacementStateProvider mode={placementMode}>
+                                    {children}
+                                  </PlacementStateProvider>
+                                ) : (
+                                  children
+                                )}
+                              </AudioVolumeProvider>
+                            </InstanceProvider>
+                          </WorldProvider>
+                        </ConfirmProvider>
+                      </TeleportProvider>
+                    </InstanceEventProvider>
+                  </UsersProvider>
+                </SpawnPointProvider>
+              </InstanceStateProvider>
+            </SharedFileProvider>
           </FileInputProvider>
         </TextInputProvider>
       </ScreenShareProvider>

--- a/src/contexts/XRiftContext.tsx
+++ b/src/contexts/XRiftContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react'
+import React, { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react'
 import type { Object3D } from 'three'
 import { InstanceStateProvider, type InstanceStateContextValue } from './InstanceStateContext'
 import { ScreenShareProvider, type ScreenShareContextValue } from './ScreenShareContext'
@@ -168,6 +168,19 @@ interface Props {
 }
 
 /**
+ * Provider の配列を合成して単一のラッパーを返す
+ * 波動拳ネストを平坦なリストに変換する
+ */
+const composeProviders = (
+  providers: Array<[React.ComponentType<any>, Record<string, unknown>]>,
+  children: ReactNode,
+): ReactNode =>
+  providers.reduceRight<ReactNode>(
+    (acc, [Provider, props]) => <Provider {...props}>{acc}</Provider>,
+    children,
+  )
+
+/**
  * XRift ワールドの情報を提供するContextProvider
  * Module Federationで動的にロードされたワールドコンポーネントに
  * 必要な情報を注入するために使用
@@ -270,41 +283,29 @@ export const XRiftProvider = ({
     unregisterInteractable,
   }), [baseUrl, interactableObjects, registerInteractable, unregisterInteractable])
 
+  const providers: Array<[React.ComponentType<any>, Record<string, unknown>]> = [
+    [ScreenShareProvider, { value: screenShareImpl }],
+    [TextInputProvider, { value: textInputImpl }],
+    [FileInputProvider, { value: fileInputImpl }],
+    [SharedFileProvider, { value: sharedFileImpl }],
+    [InstanceStateProvider, { implementation: instanceStateImplementation }],
+    [SpawnPointProvider, { implementation: spawnPointImplementation }],
+    [UsersProvider, { implementation: usersImplementation }],
+    [InstanceEventProvider, { value: instanceEventImpl }],
+    [TeleportProvider, { value: teleportImpl }],
+    [ConfirmProvider, { value: confirmImpl }],
+    [WorldProvider, { value: worldImpl }],
+    [InstanceProvider, { value: instanceImpl }],
+    [AudioVolumeProvider, { value: audioVolumeImpl }],
+  ]
+
+  if (placementMode) {
+    providers.push([PlacementStateProvider, { mode: placementMode }])
+  }
+
   return (
     <XRiftContext.Provider value={xriftContextValue}>
-      <ScreenShareProvider value={screenShareImpl}>
-        <TextInputProvider value={textInputImpl}>
-          <FileInputProvider value={fileInputImpl}>
-            <SharedFileProvider value={sharedFileImpl}>
-              <InstanceStateProvider implementation={instanceStateImplementation}>
-                <SpawnPointProvider implementation={spawnPointImplementation}>
-                  <UsersProvider implementation={usersImplementation}>
-                    <InstanceEventProvider value={instanceEventImpl}>
-                      <TeleportProvider value={teleportImpl}>
-                        <ConfirmProvider value={confirmImpl}>
-                          <WorldProvider value={worldImpl}>
-                            <InstanceProvider value={instanceImpl}>
-                              <AudioVolumeProvider value={audioVolumeImpl}>
-                                {placementMode ? (
-                                  <PlacementStateProvider mode={placementMode}>
-                                    {children}
-                                  </PlacementStateProvider>
-                                ) : (
-                                  children
-                                )}
-                              </AudioVolumeProvider>
-                            </InstanceProvider>
-                          </WorldProvider>
-                        </ConfirmProvider>
-                      </TeleportProvider>
-                    </InstanceEventProvider>
-                  </UsersProvider>
-                </SpawnPointProvider>
-              </InstanceStateProvider>
-            </SharedFileProvider>
-          </FileInputProvider>
-        </TextInputProvider>
-      </ScreenShareProvider>
+      {composeProviders(providers, children)}
     </XRiftContext.Provider>
   )
 }

--- a/src/hooks/useSharedFile.ts
+++ b/src/hooks/useSharedFile.ts
@@ -1,0 +1,34 @@
+import { useCallback } from 'react'
+import { type SharedFileContextValue, useSharedFileContext } from '../contexts/SharedFileContext'
+
+/**
+ * 共有ファイルのアップロード・一覧取得を行うhook
+ * ワールド作成者が3D空間内から共有ファイルを操作するために使用
+ *
+ * @example
+ * const { uploadSharedFile, getSharedFiles } = useSharedFile()
+ *
+ * const handleUpload = async (file: File) => {
+ *   const result = await uploadSharedFile(file, (progress) => {
+ *     console.log(`${progress}%`)
+ *   })
+ *   console.log('URL:', result.publicUrl)
+ * }
+ *
+ * @returns {{ uploadSharedFile, getSharedFiles }}
+ */
+export const useSharedFile = (): {
+  uploadSharedFile: SharedFileContextValue['uploadSharedFile']
+  getSharedFiles: SharedFileContextValue['getSharedFiles']
+} => {
+  const { uploadSharedFile, getSharedFiles } = useSharedFileContext()
+
+  const stableUploadSharedFile = useCallback(
+    (file: File, onProgress?: (progress: number) => void) => uploadSharedFile(file, onProgress),
+    [uploadSharedFile],
+  )
+
+  const stableGetSharedFiles = useCallback(() => getSharedFiles(), [getSharedFiles])
+
+  return { uploadSharedFile: stableUploadSharedFile, getSharedFiles: stableGetSharedFiles }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,15 @@ export {
 } from './contexts/PlacementStateContext'
 
 export {
+  SharedFileContext,
+  SharedFileProvider,
+  useSharedFileContext,
+  createDefaultSharedFileImplementation,
+  type SharedFileContextValue,
+  type SharedFileInfo,
+} from './contexts/SharedFileContext'
+
+export {
   VoiceVolumeOverrideContext,
   VoiceVolumeOverrideProvider,
   useVoiceVolumeOverrideContext,
@@ -198,6 +207,7 @@ export { useTeleport } from './hooks/useTeleport'
 export { useInstance } from './hooks/useInstance'
 export { useWorld } from './hooks/useWorld'
 export { useInstanceEvent } from './hooks/useInstanceEvent'
+export { useSharedFile } from './hooks/useSharedFile'
 export { useVoiceVolumeOverride, useAudioVolume } from './hooks/useAudioVolume'
 export { useDefaultFont, type FontLocale } from './hooks/useDefaultFont'
 


### PR DESCRIPTION
## Summary
- `SharedFileContext` / `SharedFileProvider` / `useSharedFile` hook を新規追加
- ワールド作成者が3D空間内から共有ファイルのアップロード（`uploadSharedFile`）・一覧取得（`getSharedFiles`）が可能になる
- 既存の `FileInputContext`（DI方式）パターンに準拠
- `XRiftProvider` に `sharedFileImplementation` prop を追加し、未指定時はデフォルト実装（console.log + ダミー返却）にフォールバック

## 対応するfrontend PR
- https://github.com/WebXR-JP/xrift-frontend/pull/1227

## Test plan
- [ ] `npm run build`（tsc）が通ること
- [ ] `sharedFileImplementation` を指定しない場合、デフォルト実装が使われること
- [ ] `useSharedFile()` で `uploadSharedFile` / `getSharedFiles` が取得できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)