### PR TITLE
feat: アイテム固有IDを提供する ItemContext を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/contexts/ItemContext.tsx
+++ b/src/contexts/ItemContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, type ReactNode, useContext, useMemo } from 'react'
+
+export type ItemContextValue = {
+  id: string
+}
+
+const ItemContext = createContext<ItemContextValue | null>(null)
+
+export function ItemProvider({
+  id,
+  children,
+}: {
+  id: string
+  children: ReactNode
+}) {
+  const value = useMemo(() => ({ id }), [id])
+  return <ItemContext.Provider value={value}>{children}</ItemContext.Provider>
+}
+
+/**
+ * 配置されたアイテムの固有IDを取得するhook
+ * Provider 外では例外をスローする
+ */
+export function useItem(): ItemContextValue {
+  const ctx = useContext(ItemContext)
+  if (!ctx) throw new Error('useItem must be used within ItemProvider')
+  return ctx
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,12 @@ export {
 } from './contexts/PlacementStateContext'
 
 export {
+  ItemProvider,
+  useItem,
+  type ItemContextValue,
+} from './contexts/ItemContext'
+
+export {
   SharedFileContext,
   SharedFileProvider,
   useSharedFileContext,


### PR DESCRIPTION
## Summary
- 配置されたアイテムごとに異なるstateを管理するため、`ItemProvider` と `useItem()` hooks を追加
- `useItem()` で配置オブジェクトのIDを取得可能に
- Provider 外では例外をスローする設計（PlacementStateContext等と同様のパターン）

## 使い方
```tsx
import { useItem } from '@xrift/world-components'

export function Item() {
  const { id } = useItem()
  // id を識別子として配置ごとのstateを管理
}
```

## 変更ファイル
- `src/contexts/ItemContext.tsx` — 新規作成
- `src/index.ts` — エクスポート追加

## Test plan
- [x] `tsc` ビルド成功を確認
- [ ] xrift-frontend 側で `useItem().id` が取得できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)