### PR TITLE
fix(BillboardY): カメラ真上/真下にあると rotation が暴れる問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.40.6",
+  "version": "0.40.7",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.40.3",
+  "version": "0.40.4",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.40.4",
+  "version": "0.40.5",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.40.7",
+  "version": "0.40.2",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/BillboardY/hooks.ts
+++ b/src/components/BillboardY/hooks.ts
@@ -1,7 +1,11 @@
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import {
+  BoxGeometry,
+  type Camera,
   Euler,
+  Mesh,
+  MeshBasicMaterial,
   type Object3D,
   Quaternion,
   Vector3,
@@ -15,45 +19,75 @@ const _parentPos = new Vector3()
 const _parentScale = new Vector3()
 const _euler = new Euler()
 
+const SENTINEL_GEOMETRY = new BoxGeometry(0.001, 0.001, 0.001)
+const SENTINEL_MATERIAL = new MeshBasicMaterial({
+  colorWrite: false,
+  depthWrite: false,
+  depthTest: false,
+})
+
+const applyBillboardRotation = (target: Object3D, camera: Camera) => {
+  _cameraWorldPos.setFromMatrixPosition(camera.matrixWorld)
+  _targetWorldPos.setFromMatrixPosition(target.matrixWorld)
+
+  const worldRotationY = getBillboardYRotation(
+    _cameraWorldPos,
+    _targetWorldPos,
+  )
+
+  if (target.parent) {
+    target.parent.matrixWorld.decompose(_parentPos, _parentQuat, _parentScale)
+    _euler.setFromQuaternion(_parentQuat, 'YXZ')
+    target.rotation.y = worldRotationY - _euler.y
+  } else {
+    target.rotation.y = worldRotationY
+  }
+}
+
 /**
  * Y軸ビルボードフック
  * 対象の Object3D を毎フレームカメラに向けてY軸のみ回転させる。
  * 親のワールド回転を考慮し、ローカル回転として正しい値を設定する。
  *
- * useFrame で `renderer.render()` 前に rotation を確定させるシンプル方式。
- * 1 frame に複数の `renderer.render` 呼び出しがあっても全て同じ matrixWorld を使う。
+ * 二段構え:
+ * 1. useFrame: メインカメラに向けて rotation を設定（renderer.render の前に1回）
+ * 2. sentinel mesh: 各 render コールの onBeforeRender で再計算
+ *    （Mirror のネステッドレンダー時に virtualCamera 向きへ更新）
  *
- * 注意:
- * - Mirror（Reflector）の鏡像内では「鏡カメラに向く」挙動にはならず、
- *   メインカメラ向きで固定される。Mirror 対応が必要な場合は別途検討。
+ * sentinel は単一・save/restore なしのシンプル構造。
+ * 複数 BillboardY が同居しても各 sentinel は自分の target しか更新しないので
+ * 干渉しない。
  */
 export const useBillboardY = <T extends Object3D>() => {
   const ref = useRef<T>(null)
 
+  // メインカメラ向きでフレームごとに rotation を確定
   useFrame(({ camera }) => {
-    const target = ref.current
-    if (!target) return
-
-    _cameraWorldPos.setFromMatrixPosition(camera.matrixWorld)
-    _targetWorldPos.setFromMatrixPosition(target.matrixWorld)
-
-    const worldRotationY = getBillboardYRotation(
-      _cameraWorldPos,
-      _targetWorldPos,
-    )
-
-    if (target.parent) {
-      target.parent.matrixWorld.decompose(
-        _parentPos,
-        _parentQuat,
-        _parentScale,
-      )
-      _euler.setFromQuaternion(_parentQuat, 'YXZ')
-      target.rotation.y = worldRotationY - _euler.y
-    } else {
-      target.rotation.y = worldRotationY
-    }
+    if (!ref.current) return
+    applyBillboardRotation(ref.current, camera)
   })
+
+  // 各 render コール時に rotation を再計算（Mirror のネステッドレンダー対応）
+  useEffect(() => {
+    if (!ref.current) return
+    const target = ref.current
+
+    const sentinel = new Mesh(SENTINEL_GEOMETRY, SENTINEL_MATERIAL)
+    sentinel.frustumCulled = false
+    sentinel.renderOrder = -Infinity
+    sentinel.layers.enableAll()
+    sentinel.onBeforeRender = (_r, _s, camera: Camera) => {
+      applyBillboardRotation(target, camera)
+      target.updateWorldMatrix(false, true)
+    }
+
+    target.add(sentinel)
+
+    return () => {
+      sentinel.onBeforeRender = () => {}
+      target.remove(sentinel)
+    }
+  }, [])
 
   return ref
 }

--- a/src/components/BillboardY/hooks.ts
+++ b/src/components/BillboardY/hooks.ts
@@ -139,7 +139,12 @@ export const useBillboardY = <T extends Object3D>() => {
       transparentPreSentinel,
       transparentPostSentinel,
     ]
-    for (const s of sentinels) target.add(s)
+    // どのカメラのレイヤー設定でも projection を通すため全レイヤーを有効化
+    // （sentinel は colorWrite/depthWrite 全 off なので描画自体は無害）
+    for (const s of sentinels) {
+      s.layers.enableAll()
+      target.add(s)
+    }
 
     return () => {
       for (const s of sentinels) {

--- a/src/components/BillboardY/hooks.ts
+++ b/src/components/BillboardY/hooks.ts
@@ -1,11 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import {
-  BoxGeometry,
-  type Camera,
   Euler,
-  Mesh,
-  MeshBasicMaterial,
   type Object3D,
   Quaternion,
   Vector3,
@@ -19,102 +15,46 @@ const _parentPos = new Vector3()
 const _parentScale = new Vector3()
 const _euler = new Euler()
 
-const SENTINEL_GEOMETRY = new BoxGeometry(0.001, 0.001, 0.001)
-
-const OPAQUE_MATERIAL = new MeshBasicMaterial({
-  colorWrite: false,
-  depthWrite: false,
-  depthTest: false,
-})
-const TRANSPARENT_MATERIAL = new MeshBasicMaterial({
-  colorWrite: false,
-  depthWrite: false,
-  depthTest: false,
-  transparent: true,
-  opacity: 0,
-})
-
-const applyBillboardRotation = (target: Object3D, camera: Camera) => {
-  _cameraWorldPos.setFromMatrixPosition(camera.matrixWorld)
-  _targetWorldPos.setFromMatrixPosition(target.matrixWorld)
-
-  const worldRotationY = getBillboardYRotation(
-    _cameraWorldPos,
-    _targetWorldPos,
-  )
-
-  if (target.parent) {
-    target.parent.matrixWorld.decompose(_parentPos, _parentQuat, _parentScale)
-    _euler.setFromQuaternion(_parentQuat, 'YXZ')
-    target.rotation.y = worldRotationY - _euler.y
-  } else {
-    target.rotation.y = worldRotationY
-  }
-}
-
 /**
  * Y軸ビルボードフック
  * 対象の Object3D を毎フレームカメラに向けてY軸のみ回転させる。
  * 親のワールド回転を考慮し、ローカル回転として正しい値を設定する。
  *
- * 二段構え:
- * 1. useFrame: メインカメラに向けて rotation を設定（renderer.render の前に1回）
- * 2. sentinel mesh × 2: 各 render コールの onBeforeRender で再計算
- *    - opaque list 用 sentinel: opaque パス開始時に rotation 更新
- *    - transparent list 用 sentinel: transparent パス開始時に rotation 更新
- *    両方必要なのは Mirror（Reflector）のネステッドレンダーで rotation が
- *    virtualCamera 向きに書き換わったあと、main render の transparent パスで
- *    描画される文字・黒背景なども正しい向きにするため。
+ * useFrame で `renderer.render()` 前に rotation を確定させる方式。
+ * 1 frame に複数の renderer.render 呼び出しがあっても全て同じ matrixWorld を使う。
  *
- * sentinel は単一・save/restore なしのシンプル構造。
- * 複数 BillboardY が同居しても各 sentinel は自分の target しか更新しないので
- * 干渉しない。
+ * 既知の制約:
+ * - Mirror（Reflector）の鏡像内では「鏡カメラに向く」挙動にはならず、
+ *   メインカメラ向きで固定される。鏡像内 billboard を正しい向きにするには
+ *   別途 hook が必要。
  */
 export const useBillboardY = <T extends Object3D>() => {
   const ref = useRef<T>(null)
 
-  // メインカメラ向きでフレームごとに rotation を確定
   useFrame(({ camera }) => {
-    if (!ref.current) return
-    applyBillboardRotation(ref.current, camera)
-  })
-
-  // 各 render コール時に rotation を再計算（Mirror のネステッドレンダー対応）
-  useEffect(() => {
-    if (!ref.current) return
     const target = ref.current
+    if (!target) return
 
-    const onBeforeRender = (
-      _r: unknown,
-      _s: unknown,
-      camera: Camera,
-    ) => {
-      applyBillboardRotation(target, camera)
-      target.updateWorldMatrix(false, true)
+    _cameraWorldPos.setFromMatrixPosition(camera.matrixWorld)
+    _targetWorldPos.setFromMatrixPosition(target.matrixWorld)
+
+    const worldRotationY = getBillboardYRotation(
+      _cameraWorldPos,
+      _targetWorldPos,
+    )
+
+    if (target.parent) {
+      target.parent.matrixWorld.decompose(
+        _parentPos,
+        _parentQuat,
+        _parentScale,
+      )
+      _euler.setFromQuaternion(_parentQuat, 'YXZ')
+      target.rotation.y = worldRotationY - _euler.y
+    } else {
+      target.rotation.y = worldRotationY
     }
-
-    const opaqueSentinel = new Mesh(SENTINEL_GEOMETRY, OPAQUE_MATERIAL)
-    opaqueSentinel.frustumCulled = false
-    opaqueSentinel.renderOrder = -Infinity
-    opaqueSentinel.layers.enableAll()
-    opaqueSentinel.onBeforeRender = onBeforeRender
-
-    const transparentSentinel = new Mesh(SENTINEL_GEOMETRY, TRANSPARENT_MATERIAL)
-    transparentSentinel.frustumCulled = false
-    transparentSentinel.renderOrder = -Infinity
-    transparentSentinel.layers.enableAll()
-    transparentSentinel.onBeforeRender = onBeforeRender
-
-    target.add(opaqueSentinel)
-    target.add(transparentSentinel)
-
-    return () => {
-      opaqueSentinel.onBeforeRender = () => {}
-      transparentSentinel.onBeforeRender = () => {}
-      target.remove(opaqueSentinel)
-      target.remove(transparentSentinel)
-    }
-  }, [])
+  })
 
   return ref
 }

--- a/src/components/BillboardY/hooks.ts
+++ b/src/components/BillboardY/hooks.ts
@@ -70,7 +70,19 @@ export const useBillboardY = <T extends Object3D>() => {
     // 回転の save/restore 用スタック
     const savedRotations: number[] = []
 
-    const applyRotation = (camera: Camera, label: string) => {
+    // DEBUG: 同じカメラインスタンスが繰り返し使われているか識別する
+    const seenCameras = new WeakMap<Camera, number>()
+    let __camCounter = 0
+    const camId = (camera: Camera): number => {
+      let id = seenCameras.get(camera)
+      if (id === undefined) {
+        id = ++__camCounter
+        seenCameras.set(camera, id)
+      }
+      return id
+    }
+
+    const applyRotation = (camera: Camera, scene: unknown, label: string) => {
       const before = target.rotation.y
       savedRotations.push(target.rotation.y)
 
@@ -103,14 +115,19 @@ export const useBillboardY = <T extends Object3D>() => {
         __billboardYFrameCounter++
         __lastFrameLogged = now
       }
+      // matrixWorld の rotation Y 成分を確認（YXZ の場合 m11=cos, m13=sin）
+      const m = target.matrixWorld.elements
+      const mwRotY = Math.atan2(m[8], m[10])
       // eslint-disable-next-line no-console
       console.log(
         `[BBY#${instanceId} f${__billboardYFrameCounter}] ${label} apply`,
         {
-          cam: camera.type,
+          cam: `${camera.type}#${camId(camera)}`,
           camMask: camera.layers.mask.toString(2),
+          sceneId: (scene as { uuid?: string })?.uuid?.slice(0, 8),
           before: +before.toFixed(3),
           after: +target.rotation.y.toFixed(3),
+          mwRotY: +mwRotY.toFixed(3),
           stack: savedRotations.length,
         },
       )
@@ -123,12 +140,15 @@ export const useBillboardY = <T extends Object3D>() => {
         target.rotation.y = saved
         target.updateWorldMatrix(false, true)
       }
+      const m = target.matrixWorld.elements
+      const mwRotY = Math.atan2(m[8], m[10])
       // eslint-disable-next-line no-console
       console.log(
         `[BBY#${instanceId} f${__billboardYFrameCounter}] ${label} restore`,
         {
           beforePop: +beforePop.toFixed(3),
           after: +target.rotation.y.toFixed(3),
+          mwRotY: +mwRotY.toFixed(3),
           stack: savedRotations.length,
           popped: saved !== undefined,
         },
@@ -141,9 +161,9 @@ export const useBillboardY = <T extends Object3D>() => {
     opaquePreSentinel.renderOrder = -Infinity
     opaquePreSentinel.onBeforeRender = (
       _r: unknown,
-      _s: unknown,
+      scene: unknown,
       camera: Camera,
-    ) => applyRotation(camera, 'opaquePre')
+    ) => applyRotation(camera, scene, 'opaquePre')
 
     const opaquePostSentinel = new Mesh(SENTINEL_GEOMETRY, OPAQUE_MATERIAL)
     opaquePostSentinel.frustumCulled = false
@@ -159,9 +179,9 @@ export const useBillboardY = <T extends Object3D>() => {
     transparentPreSentinel.renderOrder = -Infinity
     transparentPreSentinel.onBeforeRender = (
       _r: unknown,
-      _s: unknown,
+      scene: unknown,
       camera: Camera,
-    ) => applyRotation(camera, 'transparentPre')
+    ) => applyRotation(camera, scene, 'transparentPre')
 
     const transparentPostSentinel = new Mesh(
       SENTINEL_GEOMETRY,

--- a/src/components/BillboardY/hooks.ts
+++ b/src/components/BillboardY/hooks.ts
@@ -1,10 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
+import { useFrame } from '@react-three/fiber'
 import {
-  BoxGeometry,
-  type Camera,
   Euler,
-  Mesh,
-  MeshBasicMaterial,
   type Object3D,
   Quaternion,
   Vector3,
@@ -18,208 +15,45 @@ const _parentPos = new Vector3()
 const _parentScale = new Vector3()
 const _euler = new Euler()
 
-// DEBUG: 原因特定用ログ。PR マージ前に削除する
-let __billboardYInstanceCounter = 0
-let __billboardYFrameCounter = 0
-let __lastFrameLogged = -1
-
-const SENTINEL_GEOMETRY = new BoxGeometry(0.001, 0.001, 0.001)
-
-// Three.js はレンダーリストを opaque → transparent の順で処理する。
-// renderOrder はリスト内のソートにのみ影響するため、
-// opaque/transparent 両方の子要素に対応するには両方のリストに sentinel が必要。
-const OPAQUE_MATERIAL = new MeshBasicMaterial({
-  colorWrite: false,
-  depthWrite: false,
-  depthTest: false,
-})
-const TRANSPARENT_MATERIAL = new MeshBasicMaterial({
-  colorWrite: false,
-  depthWrite: false,
-  depthTest: false,
-  transparent: true,
-  opacity: 0,
-})
-
 /**
  * Y軸ビルボードフック
- * 対象の Object3D を毎フレームカメラに向けてY軸のみ回転させる
- * 親のワールド回転を考慮し、ローカル回転として正しい値を設定する
+ * 対象の Object3D を毎フレームカメラに向けてY軸のみ回転させる。
+ * 親のワールド回転を考慮し、ローカル回転として正しい値を設定する。
  *
- * 2つの sentinel メッシュ（pre/post）により、Mirror（Reflector）の
- * ネステッドレンダーと WebXR の両方に対応する。
- * - pre-sentinel (renderOrder=-Infinity): 回転を保存 → カメラ用に設定
- * - post-sentinel (renderOrder=+Infinity): 保存した回転を復元
- * スタック構造で多重ネスト（Mirror + WebXR左右眼）にも対応。
+ * useFrame で `renderer.render()` 前に rotation を確定させるシンプル方式。
+ * 1 frame に複数の `renderer.render` 呼び出しがあっても全て同じ matrixWorld を使う。
  *
- * WebXR安全性:
- * - setFromMatrixPosition(): matrixWorldを直接読み取り、updateWorldMatrixを呼ばない
- * - decompose(): 同上
- * - target.updateWorldMatrix(false, true): targetとその子のみ更新、カメラには触れない
+ * 注意:
+ * - Mirror（Reflector）の鏡像内では「鏡カメラに向く」挙動にはならず、
+ *   メインカメラ向きで固定される。Mirror 対応が必要な場合は別途検討。
  */
 export const useBillboardY = <T extends Object3D>() => {
   const ref = useRef<T>(null)
 
-  useEffect(() => {
-    if (!ref.current) return
+  useFrame(({ camera }) => {
     const target = ref.current
+    if (!target) return
 
-    // DEBUG: インスタンス識別用カウンタ
-    const instanceId = ++__billboardYInstanceCounter
+    _cameraWorldPos.setFromMatrixPosition(camera.matrixWorld)
+    _targetWorldPos.setFromMatrixPosition(target.matrixWorld)
 
-    // 回転の save/restore 用スタック
-    const savedRotations: number[] = []
-
-    // DEBUG: 同じカメラインスタンスが繰り返し使われているか識別する
-    const seenCameras = new WeakMap<Camera, number>()
-    let __camCounter = 0
-    const camId = (camera: Camera): number => {
-      let id = seenCameras.get(camera)
-      if (id === undefined) {
-        id = ++__camCounter
-        seenCameras.set(camera, id)
-      }
-      return id
-    }
-
-    const applyRotation = (camera: Camera, scene: unknown, label: string) => {
-      const before = target.rotation.y
-      savedRotations.push(target.rotation.y)
-
-      // WebXR安全: matrixWorldを直接読み取り、updateWorldMatrixを呼ばない
-      _cameraWorldPos.setFromMatrixPosition(camera.matrixWorld)
-      _targetWorldPos.setFromMatrixPosition(target.matrixWorld)
-
-      const worldRotationY = getBillboardYRotation(
-        _cameraWorldPos,
-        _targetWorldPos,
-      )
-
-      if (target.parent) {
-        target.parent.matrixWorld.decompose(
-          _parentPos,
-          _parentQuat,
-          _parentScale,
-        )
-        _euler.setFromQuaternion(_parentQuat, 'YXZ')
-        target.rotation.y = worldRotationY - _euler.y
-      } else {
-        target.rotation.y = worldRotationY
-      }
-
-      target.updateWorldMatrix(false, true)
-
-      // DEBUG: フレーム境界判定 + 発火ログ
-      const now = performance.now() | 0
-      if (now !== __lastFrameLogged) {
-        __billboardYFrameCounter++
-        __lastFrameLogged = now
-      }
-      // matrixWorld の rotation Y 成分を確認（YXZ の場合 m11=cos, m13=sin）
-      const m = target.matrixWorld.elements
-      const mwRotY = Math.atan2(m[8], m[10])
-      // eslint-disable-next-line no-console
-      console.log(
-        `[BBY#${instanceId} f${__billboardYFrameCounter}] ${label} apply`,
-        {
-          cam: `${camera.type}#${camId(camera)}`,
-          camMask: camera.layers.mask.toString(2),
-          sceneId: (scene as { uuid?: string })?.uuid?.slice(0, 8),
-          before: +before.toFixed(3),
-          after: +target.rotation.y.toFixed(3),
-          mwRotY: +mwRotY.toFixed(3),
-          stack: savedRotations.length,
-        },
-      )
-    }
-
-    const restoreRotation = (label: string) => {
-      const beforePop = target.rotation.y
-      const saved = savedRotations.pop()
-      if (saved !== undefined) {
-        target.rotation.y = saved
-        target.updateWorldMatrix(false, true)
-      }
-      const m = target.matrixWorld.elements
-      const mwRotY = Math.atan2(m[8], m[10])
-      // eslint-disable-next-line no-console
-      console.log(
-        `[BBY#${instanceId} f${__billboardYFrameCounter}] ${label} restore`,
-        {
-          beforePop: +beforePop.toFixed(3),
-          after: +target.rotation.y.toFixed(3),
-          mwRotY: +mwRotY.toFixed(3),
-          stack: savedRotations.length,
-          popped: saved !== undefined,
-        },
-      )
-    }
-
-    // opaque リスト用 sentinel
-    const opaquePreSentinel = new Mesh(SENTINEL_GEOMETRY, OPAQUE_MATERIAL)
-    opaquePreSentinel.frustumCulled = false
-    opaquePreSentinel.renderOrder = -Infinity
-    opaquePreSentinel.onBeforeRender = (
-      _r: unknown,
-      scene: unknown,
-      camera: Camera,
-    ) => applyRotation(camera, scene, 'opaquePre')
-
-    const opaquePostSentinel = new Mesh(SENTINEL_GEOMETRY, OPAQUE_MATERIAL)
-    opaquePostSentinel.frustumCulled = false
-    opaquePostSentinel.renderOrder = Infinity
-    opaquePostSentinel.onBeforeRender = () => restoreRotation('opaquePost')
-
-    // transparent リスト用 sentinel
-    const transparentPreSentinel = new Mesh(
-      SENTINEL_GEOMETRY,
-      TRANSPARENT_MATERIAL,
+    const worldRotationY = getBillboardYRotation(
+      _cameraWorldPos,
+      _targetWorldPos,
     )
-    transparentPreSentinel.frustumCulled = false
-    transparentPreSentinel.renderOrder = -Infinity
-    transparentPreSentinel.onBeforeRender = (
-      _r: unknown,
-      scene: unknown,
-      camera: Camera,
-    ) => applyRotation(camera, scene, 'transparentPre')
 
-    const transparentPostSentinel = new Mesh(
-      SENTINEL_GEOMETRY,
-      TRANSPARENT_MATERIAL,
-    )
-    transparentPostSentinel.frustumCulled = false
-    transparentPostSentinel.renderOrder = Infinity
-    transparentPostSentinel.onBeforeRender = () =>
-      restoreRotation('transparentPost')
-
-    const sentinels = [
-      opaquePreSentinel,
-      opaquePostSentinel,
-      transparentPreSentinel,
-      transparentPostSentinel,
-    ]
-    // どのカメラのレイヤー設定でも projection を通すため全レイヤーを有効化
-    // （sentinel は colorWrite/depthWrite 全 off なので描画自体は無害）
-    for (const s of sentinels) {
-      s.layers.enableAll()
-      target.add(s)
+    if (target.parent) {
+      target.parent.matrixWorld.decompose(
+        _parentPos,
+        _parentQuat,
+        _parentScale,
+      )
+      _euler.setFromQuaternion(_parentQuat, 'YXZ')
+      target.rotation.y = worldRotationY - _euler.y
+    } else {
+      target.rotation.y = worldRotationY
     }
-
-    // eslint-disable-next-line no-console
-    console.log(`[BBY#${instanceId}] mounted`, {
-      targetUuid: target.uuid,
-      parentName: target.parent?.name || target.parent?.type,
-    })
-
-    return () => {
-      for (const s of sentinels) {
-        s.onBeforeRender = () => {}
-        target.remove(s)
-      }
-      // eslint-disable-next-line no-console
-      console.log(`[BBY#${instanceId}] unmounted`)
-    }
-  }, [])
+  })
 
   return ref
 }

--- a/src/components/BillboardY/hooks.ts
+++ b/src/components/BillboardY/hooks.ts
@@ -18,6 +18,11 @@ const _parentPos = new Vector3()
 const _parentScale = new Vector3()
 const _euler = new Euler()
 
+// DEBUG: 原因特定用ログ。PR マージ前に削除する
+let __billboardYInstanceCounter = 0
+let __billboardYFrameCounter = 0
+let __lastFrameLogged = -1
+
 const SENTINEL_GEOMETRY = new BoxGeometry(0.001, 0.001, 0.001)
 
 // Three.js はレンダーリストを opaque → transparent の順で処理する。
@@ -59,10 +64,14 @@ export const useBillboardY = <T extends Object3D>() => {
     if (!ref.current) return
     const target = ref.current
 
+    // DEBUG: インスタンス識別用カウンタ
+    const instanceId = ++__billboardYInstanceCounter
+
     // 回転の save/restore 用スタック
     const savedRotations: number[] = []
 
-    const applyRotation = (camera: Camera) => {
+    const applyRotation = (camera: Camera, label: string) => {
+      const before = target.rotation.y
       savedRotations.push(target.rotation.y)
 
       // WebXR安全: matrixWorldを直接読み取り、updateWorldMatrixを呼ばない
@@ -87,14 +96,43 @@ export const useBillboardY = <T extends Object3D>() => {
       }
 
       target.updateWorldMatrix(false, true)
+
+      // DEBUG: フレーム境界判定 + 発火ログ
+      const now = performance.now() | 0
+      if (now !== __lastFrameLogged) {
+        __billboardYFrameCounter++
+        __lastFrameLogged = now
+      }
+      // eslint-disable-next-line no-console
+      console.log(
+        `[BBY#${instanceId} f${__billboardYFrameCounter}] ${label} apply`,
+        {
+          cam: camera.type,
+          camMask: camera.layers.mask.toString(2),
+          before: +before.toFixed(3),
+          after: +target.rotation.y.toFixed(3),
+          stack: savedRotations.length,
+        },
+      )
     }
 
-    const restoreRotation = () => {
+    const restoreRotation = (label: string) => {
+      const beforePop = target.rotation.y
       const saved = savedRotations.pop()
       if (saved !== undefined) {
         target.rotation.y = saved
         target.updateWorldMatrix(false, true)
       }
+      // eslint-disable-next-line no-console
+      console.log(
+        `[BBY#${instanceId} f${__billboardYFrameCounter}] ${label} restore`,
+        {
+          beforePop: +beforePop.toFixed(3),
+          after: +target.rotation.y.toFixed(3),
+          stack: savedRotations.length,
+          popped: saved !== undefined,
+        },
+      )
     }
 
     // opaque リスト用 sentinel
@@ -105,12 +143,12 @@ export const useBillboardY = <T extends Object3D>() => {
       _r: unknown,
       _s: unknown,
       camera: Camera,
-    ) => applyRotation(camera)
+    ) => applyRotation(camera, 'opaquePre')
 
     const opaquePostSentinel = new Mesh(SENTINEL_GEOMETRY, OPAQUE_MATERIAL)
     opaquePostSentinel.frustumCulled = false
     opaquePostSentinel.renderOrder = Infinity
-    opaquePostSentinel.onBeforeRender = restoreRotation
+    opaquePostSentinel.onBeforeRender = () => restoreRotation('opaquePost')
 
     // transparent リスト用 sentinel
     const transparentPreSentinel = new Mesh(
@@ -123,7 +161,7 @@ export const useBillboardY = <T extends Object3D>() => {
       _r: unknown,
       _s: unknown,
       camera: Camera,
-    ) => applyRotation(camera)
+    ) => applyRotation(camera, 'transparentPre')
 
     const transparentPostSentinel = new Mesh(
       SENTINEL_GEOMETRY,
@@ -131,7 +169,8 @@ export const useBillboardY = <T extends Object3D>() => {
     )
     transparentPostSentinel.frustumCulled = false
     transparentPostSentinel.renderOrder = Infinity
-    transparentPostSentinel.onBeforeRender = restoreRotation
+    transparentPostSentinel.onBeforeRender = () =>
+      restoreRotation('transparentPost')
 
     const sentinels = [
       opaquePreSentinel,
@@ -146,11 +185,19 @@ export const useBillboardY = <T extends Object3D>() => {
       target.add(s)
     }
 
+    // eslint-disable-next-line no-console
+    console.log(`[BBY#${instanceId}] mounted`, {
+      targetUuid: target.uuid,
+      parentName: target.parent?.name || target.parent?.type,
+    })
+
     return () => {
       for (const s of sentinels) {
         s.onBeforeRender = () => {}
         target.remove(s)
       }
+      // eslint-disable-next-line no-console
+      console.log(`[BBY#${instanceId}] unmounted`)
     }
   }, [])
 

--- a/src/components/BillboardY/hooks.ts
+++ b/src/components/BillboardY/hooks.ts
@@ -15,6 +15,11 @@ const _parentPos = new Vector3()
 const _parentScale = new Vector3()
 const _euler = new Euler()
 
+/** カメラとターゲットの水平距離がこれ以下なら rotation 更新をスキップ。
+ * カメラの真上/真下にターゲットがあるケースで atan2 が数値的に不安定になり
+ * rotation が暴れるのを防ぐ（例: 自分の頭上に出す TagDisplay）。 */
+const MIN_HORIZONTAL_DIST_SQ = 0.0001 // 0.01m
+
 /**
  * Y軸ビルボードフック
  * 対象の Object3D を毎フレームカメラに向けてY軸のみ回転させる。
@@ -25,8 +30,7 @@ const _euler = new Euler()
  *
  * 既知の制約:
  * - Mirror（Reflector）の鏡像内では「鏡カメラに向く」挙動にはならず、
- *   メインカメラ向きで固定される。鏡像内 billboard を正しい向きにするには
- *   別途 hook が必要。
+ *   メインカメラ向きで固定される。
  */
 export const useBillboardY = <T extends Object3D>() => {
   const ref = useRef<T>(null)
@@ -37,6 +41,12 @@ export const useBillboardY = <T extends Object3D>() => {
 
     _cameraWorldPos.setFromMatrixPosition(camera.matrixWorld)
     _targetWorldPos.setFromMatrixPosition(target.matrixWorld)
+
+    const dx = _cameraWorldPos.x - _targetWorldPos.x
+    const dz = _cameraWorldPos.z - _targetWorldPos.z
+
+    // カメラがターゲットの真上/真下にあると atan2 が不安定になるのでスキップ
+    if (dx * dx + dz * dz < MIN_HORIZONTAL_DIST_SQ) return
 
     const worldRotationY = getBillboardYRotation(
       _cameraWorldPos,

--- a/src/components/BillboardY/hooks.ts
+++ b/src/components/BillboardY/hooks.ts
@@ -20,10 +20,18 @@ const _parentScale = new Vector3()
 const _euler = new Euler()
 
 const SENTINEL_GEOMETRY = new BoxGeometry(0.001, 0.001, 0.001)
-const SENTINEL_MATERIAL = new MeshBasicMaterial({
+
+const OPAQUE_MATERIAL = new MeshBasicMaterial({
   colorWrite: false,
   depthWrite: false,
   depthTest: false,
+})
+const TRANSPARENT_MATERIAL = new MeshBasicMaterial({
+  colorWrite: false,
+  depthWrite: false,
+  depthTest: false,
+  transparent: true,
+  opacity: 0,
 })
 
 const applyBillboardRotation = (target: Object3D, camera: Camera) => {
@@ -51,8 +59,12 @@ const applyBillboardRotation = (target: Object3D, camera: Camera) => {
  *
  * 二段構え:
  * 1. useFrame: メインカメラに向けて rotation を設定（renderer.render の前に1回）
- * 2. sentinel mesh: 各 render コールの onBeforeRender で再計算
- *    （Mirror のネステッドレンダー時に virtualCamera 向きへ更新）
+ * 2. sentinel mesh × 2: 各 render コールの onBeforeRender で再計算
+ *    - opaque list 用 sentinel: opaque パス開始時に rotation 更新
+ *    - transparent list 用 sentinel: transparent パス開始時に rotation 更新
+ *    両方必要なのは Mirror（Reflector）のネステッドレンダーで rotation が
+ *    virtualCamera 向きに書き換わったあと、main render の transparent パスで
+ *    描画される文字・黒背景なども正しい向きにするため。
  *
  * sentinel は単一・save/restore なしのシンプル構造。
  * 複数 BillboardY が同居しても各 sentinel は自分の target しか更新しないので
@@ -72,20 +84,35 @@ export const useBillboardY = <T extends Object3D>() => {
     if (!ref.current) return
     const target = ref.current
 
-    const sentinel = new Mesh(SENTINEL_GEOMETRY, SENTINEL_MATERIAL)
-    sentinel.frustumCulled = false
-    sentinel.renderOrder = -Infinity
-    sentinel.layers.enableAll()
-    sentinel.onBeforeRender = (_r, _s, camera: Camera) => {
+    const onBeforeRender = (
+      _r: unknown,
+      _s: unknown,
+      camera: Camera,
+    ) => {
       applyBillboardRotation(target, camera)
       target.updateWorldMatrix(false, true)
     }
 
-    target.add(sentinel)
+    const opaqueSentinel = new Mesh(SENTINEL_GEOMETRY, OPAQUE_MATERIAL)
+    opaqueSentinel.frustumCulled = false
+    opaqueSentinel.renderOrder = -Infinity
+    opaqueSentinel.layers.enableAll()
+    opaqueSentinel.onBeforeRender = onBeforeRender
+
+    const transparentSentinel = new Mesh(SENTINEL_GEOMETRY, TRANSPARENT_MATERIAL)
+    transparentSentinel.frustumCulled = false
+    transparentSentinel.renderOrder = -Infinity
+    transparentSentinel.layers.enableAll()
+    transparentSentinel.onBeforeRender = onBeforeRender
+
+    target.add(opaqueSentinel)
+    target.add(transparentSentinel)
 
     return () => {
-      sentinel.onBeforeRender = () => {}
-      target.remove(sentinel)
+      opaqueSentinel.onBeforeRender = () => {}
+      transparentSentinel.onBeforeRender = () => {}
+      target.remove(opaqueSentinel)
+      target.remove(transparentSentinel)
     }
   }, [])
 


### PR DESCRIPTION
## 概要
TagBoard の TagDisplay でタグの色背景・黒背景が **Mirror に映ったときぐるぐる回り続ける** 問題を修正。

## 原因
`useBillboardY` は内部で `atan2(camera.x - target.x, camera.z - target.z)` で billboard の Y 回転を計算している。

TagDisplay は **localUser の頭上にも出る**（自分のタグも他人に見せる仕様）ので、自分のカメラ位置と TagDisplay の outer group の位置が **X, Z で完全一致** する。結果として：
- \`dx = 0, dz = 0\`
- \`atan2(0, 0)\` は仕様上 0 を返すが、浮動小数点誤差で **毎フレーム微妙に違う値**を返す（最下位 bit レベルの揺れ）
- 計算された rotation がランダムに変動 → 数値が暴走

普段は自分の頭の真上は視界に入らないので気付かないが、**Mirror で反射する**とその暴走 rotation が見えてぐるぐる回って見える。

## 修正
水平距離の二乗が \`MIN_HORIZONTAL_DIST_SQ\` (1cm²) 未満の場合、rotation 更新をスキップして前フレームの値を保持する。

```ts
const dx = _cameraWorldPos.x - _targetWorldPos.x
const dz = _cameraWorldPos.z - _targetWorldPos.z
if (dx * dx + dz * dz < MIN_HORIZONTAL_DIST_SQ) return
```

実用上、カメラの真上/真下にある billboard はカメラから見て向きが変わらない（テクスチャの面が見えない/真正面）ので、rotation 固定で違和感は出ない。

## おまけ: sentinel パターンの撤去
このバグの調査過程で、Mirror 対応のために導入されていた sentinel メッシュ（PR #125）が複数 BillboardY 同居時にレンダーリスト順序の前提が崩れて壊れることが判明。シンプルに \`useFrame\` で rotation を確定させる方式に戻した。

トレードオフとして **Mirror の鏡像内で billboard が「鏡カメラに向く」挙動はしなくなる**（メインカメラ向きで固定）。今のワールドではこれに依存していないため許容。Mirror 対応が必要になった時点で別 hook として opt-in 提供する想定。

## バージョン
0.40.1 → 0.40.2

## Test plan
- [x] TagBoard でタグ使用中にアイテム設置後、色背景・黒背景が振動しないことを確認
- [x] Mirror に映った TagDisplay がぐるぐる回らないこと
- [x] 通常の BillboardY 利用（離れた位置のアイテム等）の挙動が変わらないこと
- [x] BillboardY の utils テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)