### PR TITLE
fix(BillboardY): sentinel パターンを撤去し useFrame ベースに置き換え

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.40.0",
+  "version": "0.40.2",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/BillboardY/hooks.ts
+++ b/src/components/BillboardY/hooks.ts
@@ -10,15 +10,23 @@ import { getBillboardYRotation } from './utils'
 
 const _cameraWorldPos = new Vector3()
 const _targetWorldPos = new Vector3()
+const _cameraForward = new Vector3()
+const _virtualCameraPos = new Vector3()
 const _parentQuat = new Quaternion()
 const _parentPos = new Vector3()
 const _parentScale = new Vector3()
 const _euler = new Euler()
 
-/** カメラとターゲットの水平距離がこれ以下なら rotation 更新をスキップ。
- * カメラの真上/真下にターゲットがあるケースで atan2 が数値的に不安定になり
- * rotation が暴れるのを防ぐ（例: 自分の頭上に出す TagDisplay や NameTag）。 */
-const MIN_HORIZONTAL_DIST_SQ = 0.0001 // (0.01m)²
+/** カメラとターゲットが水平方向にこれ以下に近接していたら「仮想カメラ位置」へ
+ * フォールバックする閾値。0.1m = 10cm。
+ *
+ * 自分の頭上に置く NameTag / TagDisplay のように XZ 座標がカメラと一致するケースで
+ * atan2(0, 0) が暴れるのを防ぐ。歩行時の frame ラグ（〜25mm/frame）や
+ * 走行時のラグ（〜83mm/frame）もこの範囲に収まる。 */
+const NEAR_CAMERA_DIST_SQ = 0.01 // (0.1m)²
+
+/** 仮想カメラを実カメラの視線方向何メートル先に置くか */
+const VIRTUAL_CAMERA_DISTANCE = 1.0
 
 /**
  * Y軸ビルボードフック
@@ -29,6 +37,14 @@ const MIN_HORIZONTAL_DIST_SQ = 0.0001 // (0.01m)²
  * - useFrame で renderer.render() の前に rotation を確定する
  * - 1 フレーム中に複数の renderer.render 呼び出しがあっても全て同じ matrixWorld
  *   を使うので、複数 BillboardY 同居や opaque/transparent 混在でも安定して動作する
+ *
+ * カメラ真上/真下対応:
+ * - target がカメラの真上/真下にあると atan2(0, 0) が暴れるため、水平距離が
+ *   {@link NEAR_CAMERA_DIST_SQ} 以下のときは「カメラの視線方向 1m 先」を
+ *   仮想カメラ位置として使い、そこから target を見ているとして rotation を計算する
+ *   （視線方向に合わせて billboard が回転する形になる）
+ * - 視線が真上/真下のときは forward の XZ 成分が無くなるので前フレームの rotation
+ *   を保持する
  *
  * 既知の制約:
  * - Mirror（Reflector）の鏡像内では billboard が「鏡カメラに向く」挙動はしない
@@ -45,16 +61,30 @@ export const useBillboardY = <T extends Object3D>() => {
     _cameraWorldPos.setFromMatrixPosition(camera.matrixWorld)
     _targetWorldPos.setFromMatrixPosition(target.matrixWorld)
 
+    // 通常はカメラ実位置を使う
+    let refPos: Vector3 = _cameraWorldPos
+
     const dx = _cameraWorldPos.x - _targetWorldPos.x
     const dz = _cameraWorldPos.z - _targetWorldPos.z
+    if (dx * dx + dz * dz < NEAR_CAMERA_DIST_SQ) {
+      // カメラが target の真上/真下付近 → 視線方向 1m 先を仮想カメラ位置に
+      camera.getWorldDirection(_cameraForward)
+      _cameraForward.y = 0
+      const fwdLenSq =
+        _cameraForward.x * _cameraForward.x +
+        _cameraForward.z * _cameraForward.z
+      if (fwdLenSq < NEAR_CAMERA_DIST_SQ) {
+        // 視線が真上/真下 → 前フレームの rotation を保持
+        return
+      }
+      _cameraForward.normalize()
+      _virtualCameraPos
+        .copy(_cameraWorldPos)
+        .addScaledVector(_cameraForward, VIRTUAL_CAMERA_DISTANCE)
+      refPos = _virtualCameraPos
+    }
 
-    // カメラの真上/真下に target があるとき atan2 が暴れるのでスキップ
-    if (dx * dx + dz * dz < MIN_HORIZONTAL_DIST_SQ) return
-
-    const worldRotationY = getBillboardYRotation(
-      _cameraWorldPos,
-      _targetWorldPos,
-    )
+    const worldRotationY = getBillboardYRotation(refPos, _targetWorldPos)
 
     if (target.parent) {
       target.parent.matrixWorld.decompose(

--- a/src/components/BillboardY/hooks.ts
+++ b/src/components/BillboardY/hooks.ts
@@ -1,10 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
+import { useFrame } from '@react-three/fiber'
 import {
-  BoxGeometry,
-  type Camera,
   Euler,
-  Mesh,
-  MeshBasicMaterial,
   type Object3D,
   Quaternion,
   Vector3,
@@ -18,136 +15,59 @@ const _parentPos = new Vector3()
 const _parentScale = new Vector3()
 const _euler = new Euler()
 
-const SENTINEL_GEOMETRY = new BoxGeometry(0.001, 0.001, 0.001)
-
-// Three.js はレンダーリストを opaque → transparent の順で処理する。
-// renderOrder はリスト内のソートにのみ影響するため、
-// opaque/transparent 両方の子要素に対応するには両方のリストに sentinel が必要。
-const OPAQUE_MATERIAL = new MeshBasicMaterial({
-  colorWrite: false,
-  depthWrite: false,
-  depthTest: false,
-})
-const TRANSPARENT_MATERIAL = new MeshBasicMaterial({
-  colorWrite: false,
-  depthWrite: false,
-  depthTest: false,
-  transparent: true,
-  opacity: 0,
-})
+/** カメラとターゲットの水平距離がこれ以下なら rotation 更新をスキップ。
+ * カメラの真上/真下にターゲットがあるケースで atan2 が数値的に不安定になり
+ * rotation が暴れるのを防ぐ（例: 自分の頭上に出す TagDisplay や NameTag）。 */
+const MIN_HORIZONTAL_DIST_SQ = 0.0001 // (0.01m)²
 
 /**
  * Y軸ビルボードフック
- * 対象の Object3D を毎フレームカメラに向けてY軸のみ回転させる
- * 親のワールド回転を考慮し、ローカル回転として正しい値を設定する
+ * 対象の Object3D を毎フレームカメラに向けて Y 軸のみ回転させる。
+ * 親のワールド回転を考慮し、ローカル回転として正しい値を設定する。
  *
- * 2つの sentinel メッシュ（pre/post）により、Mirror（Reflector）の
- * ネステッドレンダーと WebXR の両方に対応する。
- * - pre-sentinel (renderOrder=-Infinity): 回転を保存 → カメラ用に設定
- * - post-sentinel (renderOrder=+Infinity): 保存した回転を復元
- * スタック構造で多重ネスト（Mirror + WebXR左右眼）にも対応。
+ * 実装方針:
+ * - useFrame で renderer.render() の前に rotation を確定する
+ * - 1 フレーム中に複数の renderer.render 呼び出しがあっても全て同じ matrixWorld
+ *   を使うので、複数 BillboardY 同居や opaque/transparent 混在でも安定して動作する
  *
- * WebXR安全性:
- * - setFromMatrixPosition(): matrixWorldを直接読み取り、updateWorldMatrixを呼ばない
- * - decompose(): 同上
- * - target.updateWorldMatrix(false, true): targetとその子のみ更新、カメラには触れない
+ * 既知の制約:
+ * - Mirror（Reflector）の鏡像内では billboard が「鏡カメラに向く」挙動はしない
+ *   （メインカメラ向きで固定される）。鏡像内でも正しい向きにしたいケースは
+ *   別途検討が必要（issue #173 参照）。
  */
 export const useBillboardY = <T extends Object3D>() => {
   const ref = useRef<T>(null)
 
-  useEffect(() => {
-    if (!ref.current) return
+  useFrame(({ camera }) => {
     const target = ref.current
+    if (!target) return
 
-    // 回転の save/restore 用スタック
-    const savedRotations: number[] = []
+    _cameraWorldPos.setFromMatrixPosition(camera.matrixWorld)
+    _targetWorldPos.setFromMatrixPosition(target.matrixWorld)
 
-    const applyRotation = (camera: Camera) => {
-      savedRotations.push(target.rotation.y)
+    const dx = _cameraWorldPos.x - _targetWorldPos.x
+    const dz = _cameraWorldPos.z - _targetWorldPos.z
 
-      // WebXR安全: matrixWorldを直接読み取り、updateWorldMatrixを呼ばない
-      _cameraWorldPos.setFromMatrixPosition(camera.matrixWorld)
-      _targetWorldPos.setFromMatrixPosition(target.matrixWorld)
+    // カメラの真上/真下に target があるとき atan2 が暴れるのでスキップ
+    if (dx * dx + dz * dz < MIN_HORIZONTAL_DIST_SQ) return
 
-      const worldRotationY = getBillboardYRotation(
-        _cameraWorldPos,
-        _targetWorldPos,
+    const worldRotationY = getBillboardYRotation(
+      _cameraWorldPos,
+      _targetWorldPos,
+    )
+
+    if (target.parent) {
+      target.parent.matrixWorld.decompose(
+        _parentPos,
+        _parentQuat,
+        _parentScale,
       )
-
-      if (target.parent) {
-        target.parent.matrixWorld.decompose(
-          _parentPos,
-          _parentQuat,
-          _parentScale,
-        )
-        _euler.setFromQuaternion(_parentQuat, 'YXZ')
-        target.rotation.y = worldRotationY - _euler.y
-      } else {
-        target.rotation.y = worldRotationY
-      }
-
-      target.updateWorldMatrix(false, true)
+      _euler.setFromQuaternion(_parentQuat, 'YXZ')
+      target.rotation.y = worldRotationY - _euler.y
+    } else {
+      target.rotation.y = worldRotationY
     }
-
-    const restoreRotation = () => {
-      const saved = savedRotations.pop()
-      if (saved !== undefined) {
-        target.rotation.y = saved
-        target.updateWorldMatrix(false, true)
-      }
-    }
-
-    // opaque リスト用 sentinel
-    const opaquePreSentinel = new Mesh(SENTINEL_GEOMETRY, OPAQUE_MATERIAL)
-    opaquePreSentinel.frustumCulled = false
-    opaquePreSentinel.renderOrder = -Infinity
-    opaquePreSentinel.onBeforeRender = (
-      _r: unknown,
-      _s: unknown,
-      camera: Camera,
-    ) => applyRotation(camera)
-
-    const opaquePostSentinel = new Mesh(SENTINEL_GEOMETRY, OPAQUE_MATERIAL)
-    opaquePostSentinel.frustumCulled = false
-    opaquePostSentinel.renderOrder = Infinity
-    opaquePostSentinel.onBeforeRender = restoreRotation
-
-    // transparent リスト用 sentinel
-    const transparentPreSentinel = new Mesh(
-      SENTINEL_GEOMETRY,
-      TRANSPARENT_MATERIAL,
-    )
-    transparentPreSentinel.frustumCulled = false
-    transparentPreSentinel.renderOrder = -Infinity
-    transparentPreSentinel.onBeforeRender = (
-      _r: unknown,
-      _s: unknown,
-      camera: Camera,
-    ) => applyRotation(camera)
-
-    const transparentPostSentinel = new Mesh(
-      SENTINEL_GEOMETRY,
-      TRANSPARENT_MATERIAL,
-    )
-    transparentPostSentinel.frustumCulled = false
-    transparentPostSentinel.renderOrder = Infinity
-    transparentPostSentinel.onBeforeRender = restoreRotation
-
-    const sentinels = [
-      opaquePreSentinel,
-      opaquePostSentinel,
-      transparentPreSentinel,
-      transparentPostSentinel,
-    ]
-    for (const s of sentinels) target.add(s)
-
-    return () => {
-      for (const s of sentinels) {
-        s.onBeforeRender = () => {}
-        target.remove(s)
-      }
-    }
-  }, [])
+  })
 
   return ref
 }


### PR DESCRIPTION
## 概要
TagBoard の TagDisplay の **opaque な色背景** が、複数 BillboardY が同居する状況（タグ使用中にアイテム設置など）で一定方向に固定される問題を修正。さらに、**自分の頭上に出す NameTag/TagDisplay が移動中に進行方向を向く**問題も併せて修正。

## 修正内容

### 1. sentinel パターン → useFrame 方式
PR #125 で導入した sentinel + \`onBeforeRender\` + save/restore スタック方式は、three.js 標準のレンダーパス順序（opaque list 全体 → transparent list 全体）を前提にしていた。

しかし複数 BillboardY や、uikit の独自パイプライン・特定 layer の overlay pass などが混在する環境では実際のレンダー順序が想定通りにならない。結果として opaque content（色背景）の matrixWorld が、rotation 適用前の状態で draw されるなど不整合が発生する。

xrift-frontend の NameTag が同じ \`BillboardY\` を使ってるのに無事なのは「中身が全 transparent material で opaque list が空」「UI overlay layer で別パス」という偶然の組み合わせのおかげで、**library として利用者に要求して良い条件ではない**。

詳細は issue #173 にまとまっています。

\`useFrame\` で \`renderer.render()\` の前に rotation を確定する方式に変更：
- 1 frame に複数の \`renderer.render\` 呼び出しがあっても全 render が同じ matrixWorld を共有
- opaque/transparent 混在でも問題なし
- レンダーパス順序の前提なし

### 2. カメラ真上/真下時の仮想カメラフォールバック
useFrame 化後に判明した別問題：自分の頭上に出す NameTag や TagDisplay は、カメラと target の XZ 座標がほぼ一致するため、frame ラグで生じる微小な dx/dz が「移動方向ベクトル」になり、移動中に billboard が進行方向を向く。

\`\`\`
camera.matrixWorld:  head sync 等で「今フレーム」の値
target.matrixWorld:  親 group の position 更新が scene.updateMatrixWorld 前なので「前フレーム」の値
↓
dx, dz = velocity * dt = 進行方向ベクトル
\`\`\`

単純な距離閾値ガード（更新スキップ）では frame ラグの dx, dz が閾値を超えてしまい防げないので、**水平距離が 10cm² 未満のときは「実カメラの視線方向 1m 先」を仮想カメラ位置として使い、そこから target を見ているとして rotation を計算する**：

\`\`\`ts
if (dx * dx + dz * dz < NEAR_CAMERA_DIST_SQ) {
  camera.getWorldDirection(_cameraForward)
  _cameraForward.y = 0
  if (_cameraForward.x ** 2 + _cameraForward.z ** 2 < NEAR_CAMERA_DIST_SQ) return
  _cameraForward.normalize()
  _virtualCameraPos.copy(_cameraWorldPos).addScaledVector(_cameraForward, VIRTUAL_CAMERA_DISTANCE)
  refPos = _virtualCameraPos
}
const worldRotationY = getBillboardYRotation(refPos, _targetWorldPos)
\`\`\`

これで：
- **静止時**: forward 方向ベース（atan2 不安定なし）
- **走行時 frame ラグ**（〜83mm/frame）でも 1m の forward オフセットの方が支配的なので影響を受けない
- 視覚的には「自分の頭上の billboard が、自分の視線方向に少し倒れて見える」自然な挙動

視線が真上/真下のときは forward の XZ 成分が消えるので、その場合は前フレームの rotation を保持。

## トレードオフ（許容）
**Mirror（Reflector）の鏡像内で billboard が「鏡カメラに向く」挙動はしなくなる**（メインカメラ向きで固定される）。

現状ワールドで「鏡像内 billboard 向き」に依存するユースケースはない想定。必要になったら別 hook（\`useBillboardYWithMirror\` 等）として opt-in 提供する想定。issue #173 に記録あり。

## バージョン
0.40.1 → 0.40.2

## Test plan
- [x] \`getBillboardYRotation\` の utils テスト pass
- [x] TypeScript ビルド OK
- [ ] 動作確認: TagBoard でタグ使用 + xrift-item-robot 設置で色背景がカメラ追従すること
- [ ] 動作確認: NameTag が従来通り動作すること
- [ ] 動作確認: 静止状態で rotation が暴れないこと
- [ ] 動作確認: アバター移動時に rotation が進行方向に向かないこと
- [ ] 動作確認: 真上を向いて自分の NameTag/TagDisplay を見上げると、視線方向に billboard が自然に倒れて見える

## 関連
- issue #173: 根本原因と試したアプローチの記録
- 元 PR #172（クローズ済み）: 試行錯誤の履歴

🤖 Generated with [Claude Code](https://claude.com/claude-code)