### PR TITLE
feat(DevEnvironment): useUsers でローカルユーザー情報を取得可能に

### DIFF
--- a/dev/main.tsx
+++ b/dev/main.tsx
@@ -1,9 +1,12 @@
+import { useRef } from 'react'
 import { createRoot } from 'react-dom/client'
+import { useFrame } from '@react-three/fiber'
 import { RigidBody } from '@react-three/rapier'
 import { DevEnvironment } from '../src/components/DevEnvironment'
 import { SpawnPoint } from '../src/components/SpawnPoint'
 import { TextInputProvider, createDefaultTextInputImplementation } from '../src/contexts/TextInputContext'
 import { TestScene } from '../src/scenes/TestScene'
+import { useUsers } from '../src/contexts/UsersContext'
 
 const textInput = createDefaultTextInputImplementation()
 
@@ -18,17 +21,59 @@ function Floor() {
   )
 }
 
+const debugOverlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: 12,
+  left: 12,
+  padding: '8px 12px',
+  background: 'rgba(0, 0, 0, 0.6)',
+  color: '#fff',
+  font: '12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace',
+  borderRadius: 4,
+  pointerEvents: 'none',
+  whiteSpace: 'pre',
+  zIndex: 1000,
+}
+
+function MovementDebugReader({
+  targetRef,
+}: {
+  targetRef: React.RefObject<HTMLPreElement>
+}) {
+  const { getLocalMovement, localUser } = useUsers()
+  useFrame(() => {
+    if (!targetRef.current) return
+    const m = getLocalMovement()
+    const fmt = (n: number) => n.toFixed(2)
+    targetRef.current.textContent = [
+      `user      : ${localUser?.displayName ?? 'null'} (${localUser?.id ?? 'null'})`,
+      `position  : x=${fmt(m.position.x)} y=${fmt(m.position.y)} z=${fmt(m.position.z)}`,
+      `direction : x=${fmt(m.direction.x)} z=${fmt(m.direction.z)}`,
+      `speed     : h=${fmt(m.horizontalSpeed)} v=${fmt(m.verticalSpeed)}`,
+      `rotation  : yaw=${fmt(m.rotation.yaw)} pitch=${fmt(m.rotation.pitch)}`,
+      `grounded  : ${m.isGrounded}`,
+      `jumping   : ${m.isJumping}`,
+    ].join('\n')
+  })
+  return null
+}
+
 function App() {
+  const debugRef = useRef<HTMLPreElement>(null)
   return (
-    <DevEnvironment>
-      <ambientLight intensity={1} />
-      <directionalLight position={[5, 10, 5]} intensity={1} castShadow />
-      <TextInputProvider value={textInput}>
-        <Floor />
-        <SpawnPoint position={[5, 0, 5]} yaw={180} />
-        <TestScene />
-      </TextInputProvider>
-    </DevEnvironment>
+    <>
+      <DevEnvironment>
+        <ambientLight intensity={1} />
+        <directionalLight position={[5, 10, 5]} intensity={1} castShadow />
+        <TextInputProvider value={textInput}>
+          <Floor />
+          <SpawnPoint position={[5, 0, 5]} yaw={180} />
+          <TestScene />
+          <MovementDebugReader targetRef={debugRef} />
+        </TextInputProvider>
+      </DevEnvironment>
+      <pre ref={debugRef} style={debugOverlayStyle} />
+    </>
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.40.2",
+  "version": "0.41.0",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/DevEnvironment/components/PhysicsPlayer.tsx
+++ b/src/components/DevEnvironment/components/PhysicsPlayer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import type { MutableRefObject } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import {
   CapsuleCollider,
@@ -10,12 +11,14 @@ import { Vector3 } from 'three'
 import type { Group, Mesh } from 'three'
 import { useSpawnPoint } from '../../../hooks/useSpawnPoint'
 import { LAYERS } from '../../../constants/layers'
+import type { PlayerMovement } from '../../../types/movement'
 import {
   PLAYER_HALF_HEIGHT,
   PLAYER_RADIUS,
   JUMP_VELOCITY,
   LINEAR_DAMPING,
   CAMERA_Y_OFFSET,
+  DEV_AVATAR_HEIGHT,
 } from '../constants'
 
 interface Props {
@@ -23,15 +26,15 @@ interface Props {
   spawnPosition: [number, number, number]
   respawnThreshold: number
   allowInfiniteJump: boolean
+  movementRef?: MutableRefObject<PlayerMovement>
 }
-
-const DUMMY_AVATAR_HEIGHT = 1.5
 
 export function PhysicsPlayer({
   moveSpeed,
   spawnPosition,
   respawnThreshold,
   allowInfiniteJump,
+  movementRef,
 }: Props) {
   const rigidBodyRef = useRef<RapierRigidBody>(null)
   const avatarGroupRef = useRef<Group>(null)
@@ -170,19 +173,41 @@ export function PhysicsPlayer({
     camera.position.set(pos.x, pos.y + CAMERA_Y_OFFSET, pos.z)
 
     // --- DummyAvatar 位置同期 ---
+    camera.getWorldDirection(forwardRef.current)
+    const yaw = -Math.atan2(forwardRef.current.x, -forwardRef.current.z)
+    const pitch = Math.asin(forwardRef.current.y)
     if (avatarGroupRef.current) {
       avatarGroupRef.current.position.set(
         pos.x,
         pos.y + CAMERA_Y_OFFSET,
         pos.z,
       )
-      camera.getWorldDirection(forwardRef.current)
-      const yaw = -Math.atan2(forwardRef.current.x, -forwardRef.current.z)
-      const pitch = Math.asin(forwardRef.current.y)
       avatarGroupRef.current.rotation.set(0, yaw, 0)
       if (headRef.current) {
         headRef.current.rotation.set(pitch, 0, 0)
       }
+    }
+
+    // --- useUsers 用の PlayerMovement を更新（足元基準） ---
+    if (movementRef) {
+      const m = movementRef.current
+      m.position.x = pos.x
+      m.position.y = pos.y - (PLAYER_HALF_HEIGHT + PLAYER_RADIUS)
+      m.position.z = pos.z
+      if (len > 0) {
+        m.direction.x = moveX / moveSpeed
+        m.direction.z = moveZ / moveSpeed
+        m.horizontalSpeed = moveSpeed
+      } else {
+        m.direction.x = 0
+        m.direction.z = 0
+        m.horizontalSpeed = 0
+      }
+      m.verticalSpeed = vy
+      m.rotation.yaw = yaw
+      m.rotation.pitch = pitch
+      m.isGrounded = isGroundedRef.current
+      m.isJumping = !isGroundedRef.current && vy > 0
     }
 
     // --- リスポーン ---
@@ -237,8 +262,8 @@ export function PhysicsPlayer({
           <boxGeometry args={[0.2, 0.1, 0.2]} />
           <meshLambertMaterial color="#ffcccc" />
         </mesh>
-        <mesh castShadow position={[0, -DUMMY_AVATAR_HEIGHT * 0.55, 0]}>
-          <boxGeometry args={[0.3, DUMMY_AVATAR_HEIGHT, 0.1]} />
+        <mesh castShadow position={[0, -DEV_AVATAR_HEIGHT * 0.55, 0]}>
+          <boxGeometry args={[0.3, DEV_AVATAR_HEIGHT, 0.1]} />
           <meshLambertMaterial color="#ccffcc" />
         </mesh>
       </group>

--- a/src/components/DevEnvironment/constants.ts
+++ b/src/components/DevEnvironment/constants.ts
@@ -21,3 +21,18 @@ export const CROSSHAIR_SIZE = 20
 export const CROSSHAIR_THICKNESS = 2
 export const CROSSHAIR_ACTIVE_THICKNESS = 3
 export const HIGHLIGHT_COLOR = '#4dabf7'
+
+/**
+ * DevEnvironment 上のローカルユーザー定数
+ * 本番環境では xrift-frontend が UsersProvider に実装を注入するが、
+ * DevEnvironment ではダミーのユーザー情報を提供して useUsers を機能させる
+ */
+export const DEV_LOCAL_USER_ID = 'dev-local-user'
+export const DEV_LOCAL_USER_DISPLAY_NAME = 'Dev User'
+
+/**
+ * DummyAvatar の見た目に基づく高さ情報
+ * eyeHeight はカプセル底面（地面）からカメラまでの距離
+ */
+export const DEV_AVATAR_HEIGHT = 1.5
+export const DEV_EYE_HEIGHT = PLAYER_HALF_HEIGHT + PLAYER_RADIUS + CAMERA_Y_OFFSET

--- a/src/components/DevEnvironment/index.tsx
+++ b/src/components/DevEnvironment/index.tsx
@@ -1,8 +1,11 @@
-import { useCallback, useMemo, useState, useSyncExternalStore } from 'react'
+import { useCallback, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { PointerLockControls } from '@react-three/drei'
 import { Physics } from '@react-three/rapier'
 import { SpawnPointProvider } from '../../contexts/SpawnPointContext'
+import { UsersProvider, type UsersContextValue, type User } from '../../contexts/UsersContext'
+import type { PlayerMovement } from '../../types/movement'
+import type { AvatarHeight } from '../../types/avatar'
 import { PCFShadowMap } from 'three'
 import type { Props } from './types'
 import { toThreeOutputBufferType } from './utils'
@@ -14,12 +17,30 @@ import {
   DEFAULT_CAMERA_FAR,
   MOVE_SPEED,
   RESPAWN_Y_THRESHOLD,
+  DEV_LOCAL_USER_ID,
+  DEV_LOCAL_USER_DISPLAY_NAME,
+  DEV_AVATAR_HEIGHT,
+  DEV_EYE_HEIGHT,
 } from './constants'
 import { PhysicsPlayer } from './components/PhysicsPlayer'
 import { CenterRaycaster } from './components/CenterRaycaster'
 import { Crosshair } from './components/Crosshair'
 import { PointerLockStatus } from './components/PointerLockStatus'
 import { ControlsHelp } from './components/ControlsHelp'
+
+const DEV_LOCAL_USER: User = {
+  id: DEV_LOCAL_USER_ID,
+  displayName: DEV_LOCAL_USER_DISPLAY_NAME,
+  avatarUrl: null,
+  isGuest: true,
+}
+
+const DEV_LOCAL_AVATAR_HEIGHT: AvatarHeight = {
+  height: DEV_AVATAR_HEIGHT,
+  eyeHeight: DEV_EYE_HEIGHT,
+}
+
+const EMPTY_REMOTE_USERS: User[] = []
 
 export type DevEnvironmentProps = Props
 
@@ -58,6 +79,30 @@ export function DevEnvironment({
   )
   const handleHitChange = useCallback((hit: boolean) => setIsHit(hit), [])
 
+  // ローカルユーザーの位置情報を保持する ref。PhysicsPlayer が毎フレーム書き込み、
+  // useUsers().getLocalMovement() がここから読み取る（再レンダリングは発生しない）
+  const localMovementRef = useRef<PlayerMovement>({
+    position: { x: spawnPosition[0], y: spawnPosition[1], z: spawnPosition[2] },
+    direction: { x: 0, z: 0 },
+    horizontalSpeed: 0,
+    verticalSpeed: 0,
+    rotation: { yaw: 0, pitch: 0 },
+    isGrounded: true,
+    isJumping: false,
+  })
+
+  const usersImplementation = useMemo<UsersContextValue>(
+    () => ({
+      localUser: DEV_LOCAL_USER,
+      remoteUsers: EMPTY_REMOTE_USERS,
+      getMovement: () => undefined,
+      getLocalMovement: () => localMovementRef.current,
+      getAvatarHeight: () => undefined,
+      getLocalAvatarHeight: () => DEV_LOCAL_AVATAR_HEIGHT,
+    }),
+    [],
+  )
+
   const gravity = physicsConfig?.gravity ?? DEFAULT_GRAVITY
   const allowInfiniteJump =
     physicsConfig?.allowInfiniteJump ?? DEFAULT_ALLOW_INFINITE_JUMP
@@ -92,13 +137,16 @@ export function DevEnvironment({
         <CenterRaycaster onHitChange={handleHitChange} />
         <Physics gravity={[0, -gravity, 0]} timeStep="vary">
           <SpawnPointProvider>
-            <PhysicsPlayer
-              moveSpeed={moveSpeed}
-              spawnPosition={spawnPosition}
-              respawnThreshold={respawnThreshold}
-              allowInfiniteJump={allowInfiniteJump}
-            />
-            {children}
+            <UsersProvider implementation={usersImplementation}>
+              <PhysicsPlayer
+                moveSpeed={moveSpeed}
+                spawnPosition={spawnPosition}
+                respawnThreshold={respawnThreshold}
+                allowInfiniteJump={allowInfiniteJump}
+                movementRef={localMovementRef}
+              />
+              {children}
+            </UsersProvider>
           </SpawnPointProvider>
         </Physics>
       </Canvas>


### PR DESCRIPTION
## Summary
- DevEnvironment 内に `UsersProvider` を組み込み、ダミーの `localUser` と実際のプレイヤー座標を返す `getLocalMovement` を提供
- `PhysicsPlayer` に `movementRef` プロパティを追加し、毎フレーム位置・向き・速度・接地状態を ref に書き込む（再レンダリングは起こさない）
- `getLocalAvatarHeight` は `DummyAvatar` の見た目に揃えた値（`height: 1.5`、`eyeHeight: PLAYER_HALF_HEIGHT + PLAYER_RADIUS + CAMERA_Y_OFFSET`）を返す
- `position.y` は本番実装と揃えて足元基準（カプセル底面）

## 背景
これまで DevEnvironment では `UsersProvider` が立っておらず、`useUsers().getLocalMovement()` などはデフォルトの空実装（位置 0, `localUser: null`）が返るだけだった。ワールド制作者が `useUsers` 前提のコンポーネント（TagBoard など）を DevEnvironment 上で動作確認できない問題があった。

## 制限事項
- `remoteUsers` は空のまま（DevEnvironment は単一ユーザー想定）
- `getMovement` / `getAvatarHeight` は常に `undefined`
- VR トラッキング情報（`vrTracking`、`isInVR`）は未対応

## Test plan
- [ ] `npm run build` が通る ✅
- [ ] `npm test` が通る ✅
- [ ] DevEnvironment 内で `useUsers().getLocalMovement()` を呼び出すコンポーネント（TagBoard 等）が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)