### PR TITLE
fix(ScreenShareDisplay): 未接続時のラベルを現状に合わせて修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xrift/world-components",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "description": "Shared components and utilities for Xrift worlds",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/components/ScreenShareDisplay/index.tsx
+++ b/src/components/ScreenShareDisplay/index.tsx
@@ -75,7 +75,7 @@ export const ScreenShareDisplay = memo(({
           textAlign="center"
           material-side={THREE.FrontSide}
         >
-          {isRoomConnected ? 'クリックして画面共有' : '他のユーザーがいると\n画面共有できます'}
+          {isRoomConnected ? 'クリックして画面共有' : '音声通話に接続できていません'}
         </Text>
       )}
     </group>


### PR DESCRIPTION
## 概要

\`xrift-frontend\` で LiveKit を常時接続化（[WebXR-JP/xrift-frontend#1280](https://github.com/WebXR-JP/xrift-frontend/pull/1280)）したため、\`isRoomConnected=false\` は「LiveKit に接続できていない異常状態」を意味するようになりました。

旧ラベル「他のユーザーがいると画面共有できます」は「2人以上いれば LiveKit に接続される」という以前のソロ未接続最適化を前提にした表現だったため、現状に合いません。

## 変更

\`\`\`diff
-{isRoomConnected ? 'クリックして画面共有' : '他のユーザーがいると\n画面共有できます'}
+{isRoomConnected ? 'クリックして画面共有' : '音声通話に接続できていません'}
\`\`\`

バージョン: \`0.41.0\` → \`0.41.1\` (patch)

## デプロイ後

このマージ後に \`xrift-frontend\` 側で \`package.json\` の \`@xrift/world-components\` を \`0.41.1\` に更新する必要があります。

## Test plan

- [x] \`npm test\` (228 tests passed)
- [x] \`npm run build\`
- [ ] xrift-frontend で動作確認（接続中にラベルが切り替わるか）

## 関連

- WebXR-JP/xrift-frontend#1279 issue
- WebXR-JP/xrift-frontend#1280 LiveKit 常時接続化 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)